### PR TITLE
Swagger-ui 생성 시 참조하는 OpenAPI 문서 파일의 경로 수정

### DIFF
--- a/.github/workflows/openapi-gen.yml
+++ b/.github/workflows/openapi-gen.yml
@@ -15,7 +15,7 @@ jobs:
         uses: Legion2/swagger-ui-action@v1
         with:
           output: swagger-ui
-          spec-file: "**/packages/server/api.yaml"
+          spec-file: "packages/server/api.yaml"
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
- GitHub Actions Workflow 가 작동하도록 Swagger-ui 생성 시 참조하는 OpenAPI 문서 파일의 경로를 수정하였습니다.