### PR TITLE
lockerIdIndex LSI에서 프로젝션이 잘못되어 있는 문제 수정

### DIFF
--- a/packages/server/db-table-cli.json
+++ b/packages/server/db-table-cli.json
@@ -40,7 +40,8 @@
       "Projection": {
         "ProjectionType": "INCLUDE",
         "NonKeyAttributes": [
-          "i",
+          "iA",
+          "d",
           "n",
           "cU"
         ]

--- a/packages/server/template.yaml
+++ b/packages/server/template.yaml
@@ -398,8 +398,9 @@ Resources:
           Projection:
             ProjectionType: INCLUDE
             NonKeyAttributes:
-              - i
+              - iA
               - n
+              - d
               - cU
       BillingMode: 'PAY_PER_REQUEST'
   FrontS3Bucket:


### PR DESCRIPTION
- 존재하지 않는 `i` 프로퍼티를 참조하며, 필요한 프로퍼티인 `iA`(isAdmin), `d`(department) 프로퍼티를 참조하지 않는 문제 수정