### PR TITLE
Building, LockerSection 의 구조가 잘못된 문제 수정

### DIFF
--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -715,9 +715,6 @@ components:
         buildings:
           type: object
           description: (서비스 설정 전용) 서비스에서 사용하는 건물의 목록입니다. 건물 번호를 키로, `Building` 을 값으로 하는 맵입니다.
-        lockers:
-          type: object
-          description: (서비스 설정 전용) 서비스에서 사용하는 사물함의 목록입니다. 학부 ID를 키로, `LockerSection` 을 값으로 하는 맵입니다.
         contact:
           type: string
     ConfigUpdateRequest:
@@ -740,9 +737,6 @@ components:
         buildings:
           type: object
           description: (서비스 설정 전용) 서비스에서 사용하는 건물의 목록입니다. 건물 번호를 키로, `Building` 을 값으로 하는 맵입니다.
-        lockers:
-          type: object
-          description: (서비스 설정 전용) 서비스에서 사용하는 사물함의 목록입니다. 학부 ID를 키로, `LockerSection` 을 값으로 하는 맵입니다.
         contact:
           type: string
     Building:
@@ -758,6 +752,9 @@ components:
           format: int32
         name:
           type: string
+        lockers:
+          type: object
+          description: 건물 내부에 존재하는 사물함의 목록입니다. "사물함 구역 이름을 키로, `LockerSection` 을 값으로 하는 맵"을 값으로 하고, 층수를 키로 하는 맵입니다.
     LockerSection:
       title: LockerSection
       description: 사물함의 한 구역입니다.

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -57,25 +57,35 @@ type DepartmentConfigDao = DaoData & ConfigDao & {
 type ServiceConfig = Config & {
 	buildings: {
 		[buildingId: string]: Building
-	},
-	lockers: {
-		[lockerName: string]: LockerSection
 	}
 }
 
 type ServiceConfigDao = DaoData & ConfigDao & {
 	b: { M: { [buildingId: string]: { M: BuildingData } } }
-	l: { M: { [lockerName: string]: { M: LockerSectionData } } }
 }
 
 type Building = {
-	id: { S: string };
-	name: { S: string };
+	id: string;
+	name: string;
+	lockers: {
+		[floor: string]: {
+			[lockerName: string]: LockerSection
+		}
+	}
 }
 
 type BuildingData = {
-	i: string;
-	n: string;
+	i: { S: string };
+	n: { S: string };
+	l: {
+		M: {
+			[floor: string]: {
+				M: {
+					[lockerName: string]: LockerSectionData
+				}
+			}
+		}
+	}
 }
 
 type LockerSection = {


### PR DESCRIPTION
- ServiceConfig 에서 불필요하게 분리된 `buildings`, `lockers` 를 `buildings` 로 통합 후 `Building` 타입이 사물함을 표현하도록 수정
- 기존 구조가 사물함이 존재하는 층을 표현하지 못했던 문제 수정