### PR TITLE
DynamoDB에서 `aT` 예약어로 인해 DB 쿼리가 불가능한 문제 수정

### DIFF
--- a/packages/server/src/auth/data.ts
+++ b/packages/server/src/auth/data.ts
@@ -13,7 +13,10 @@ export const revokeToken = async function(
 		TableName,
 		Key: { type: { S: 'user' }, id: { S: `${id}` } },
 		UpdateExpression: 'REMOVE aT',
-		ConditionExpression: 'aT = :token',
+		ConditionExpression: '#aT = :token',
+		ExpressionAttributeNames: {
+			'#aT': 'aT'
+		},
 		ExpressionAttributeValues: {
 			':token': { S: token }
 		},
@@ -35,7 +38,10 @@ export const issueToken = async function(
 	const req: UpdateItemInput = {
 		TableName,
 		Key: { type: { S: 'user' }, id: { S: `${id}` } },
-		UpdateExpression: 'SET aT = :token, eO = :expiresOn',
+		UpdateExpression: 'SET #aT = :token, eO = :expiresOn',
+		ExpressionAttributeNames: {
+			'#aT': 'aT'
+		},
 		...(id !== adminId && { ConditionExpression: 'attribute_exists(d)' }),
 		ExpressionAttributeValues: {
 			':token': { S: token },

--- a/packages/server/src/config/data.ts
+++ b/packages/server/src/config/data.ts
@@ -178,7 +178,7 @@ export const updateConfig = async function(config: ConfigUpdateRequest) {
 	}
 	if (config.activateTo) {
 		attributes[':activateTo'] = { S: config.activateTo };
-		updateExp = `${updateExp ? ',' : 'SET'} aT = :activateTo`;
+		updateExp = `${updateExp ? ',' : 'SET'} #aT = :activateTo`;
 	}
 	if ((config as ServiceConfigUpdateRequest).buildings) {
 		const buildings = (config as ServiceConfigUpdateRequest).buildings;
@@ -197,6 +197,9 @@ export const updateConfig = async function(config: ConfigUpdateRequest) {
 			id: { S: config.id }
 		},
 		UpdateExpression: updateExp,
+		ExpressionAttributeNames: {
+			'#aT': 'aT'
+		},
 		ExpressionAttributeValues: attributes
 	};
 	await dynamoDB.updateItem(req).promise();

--- a/packages/server/src/locker/data.ts
+++ b/packages/server/src/locker/data.ts
@@ -10,7 +10,10 @@ export const revokeLocker = async function(
 		TableName,
 		Key: { type: { S: 'user' }, id: { S: id } },
 		UpdateExpression: 'REMOVE lockerId',
-		ConditionExpression: 'aT = :token',
+		ConditionExpression: '#aT = :token',
+		ExpressionAttributeNames: {
+			'#aT': 'aT'
+		},
 		ExpressionAttributeValues: {
 			':token': { S: token }
 		},
@@ -49,7 +52,10 @@ export const claimLocker = async function(
 		Key: { id: { S: id } },
 		UpdateExpression:
 			'SET lockerId = :lockerId, cU = :claimedUntil',
-		ConditionExpression: 'aT = :token',
+		ConditionExpression: '#aT = :token',
+		ExpressionAttributeNames: {
+			'#aT': 'aT'
+		},
 		ExpressionAttributeValues: {
 			':lockerId': { S: lockerId },
 			':token': { S: token },


### PR DESCRIPTION
- 일부 쿼리에서 `aT` 필드(`accessToken`)에 쿼리할 때 `aT` 가 `AT` 예약어와 겹쳐 쿼리가 불가함
- `ExpressionAttributeNames` 설정을 통해 예약어를 회피함으로써 쿼리가 가능하도록 수정