### PR TITLE
`/config` 엔드포인트에 인증이 걸려있다고 표시되는 문제 해결

### DIFF
--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -477,8 +477,6 @@ paths:
         - config
       summary: 전체 설정 열람
       description: 서비스의 전체 설정을 열람합니다.
-      security:
-        - UserSessionAuth: [ ]
       responses:
         '200':
           description: OK


### PR DESCRIPTION
- `/config` 엔드포인트엔 Security 가 없습니당 ㅎ