### PR TITLE
잘못된 `claimedUntil` 타입과 잘못 표시된 `lockerId` 포맷 수정

### DIFF
--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -187,7 +187,7 @@ paths:
             schema:
               $ref: '#/components/schemas/LockerClaimRequest'
             example:
-              lockerId: 21-05-B002
+              lockerId: 21-5-B002
       responses:
         '200':
           description: OK

--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -685,9 +685,9 @@ components:
           type: string
           description: 이 사물함을 사용중인 사용자의 학번입니다.
         claimedUntil:
-          type: string
-          format: date-time
-          description: 이 사물함을 사용하는 기한입니다. 없다면 무기한으로 사용중인 사물함입니다.
+          type: number
+          format: int32
+          description: 이 사물함을 사용하는 기한을 표현한 UNIX TIMESTAMP입니다. 없다면 무기한으로 사용중인 사물함입니다.
     LockerCountResponse:
       title: LockerCountResponse
       description: 사물함 갯수 요청 시 반환하는 형식입니다.

--- a/packages/server/src/user/data.ts
+++ b/packages/server/src/user/data.ts
@@ -19,7 +19,7 @@ export const fromUserDao = (dao: UserDao): User => ({
 	isAdmin: dao.iA?.BOOL ?? false,
 	department: dao.d?.S,
 	...(dao.lockerId?.S && { lockerId: dao.lockerId?.S }),
-	...(dao.cU?.S && { lockerId: dao.cU?.S })
+	...(dao.cU?.N && { claimedUntil: parseInt(dao.cU?.N) })
 });
 export const toUserDao = (user: User): UserDao => ({
 	type: { S: 'user' },
@@ -28,7 +28,7 @@ export const toUserDao = (user: User): UserDao => ({
 	iA: { BOOL: user.isAdmin },
 	d: { S: user.department },
 	...(user.lockerId && { lockerId: { S: user.lockerId } }),
-	...(user.claimedUntil && { cU: { S: user.claimedUntil } })
+	...(user.claimedUntil && { cU: { N: `${user.claimedUntil}` } })
 });
 
 export const getUser = async function (id: string): Promise<User> {
@@ -98,7 +98,7 @@ export const updateUser = async function (info: UserUpdateRequest): Promise<User
 		updateExp += `${updateExp ? ',' : 'SET'} lockerId = :lockerId`;
 	}
 	if (info.claimedUntil) {
-		attributes[':claimedUntil'] = { S: info.claimedUntil };
+		attributes[':claimedUntil'] = { N: `${info.claimedUntil}` };
 		updateExp += `${updateExp ? ',' : 'SET'} cU = :claimedUntil`;
 	}
 	if (info.lockerId === null) {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -13,7 +13,7 @@ type User = {
 	isAdmin: boolean;
 	department: string;
 	lockerId?: string;
-	claimedUntil?: string;
+	claimedUntil?: number;
 };
 
 type UserUpdateRequest = {
@@ -22,7 +22,7 @@ type UserUpdateRequest = {
 	isAdmin?: boolean;
 	department?: string;
 	lockerId?: string | null;
-	claimedUntil?: string | null;
+	claimedUntil?: number | null;
 };
 
 type UserDeleteRequest = {
@@ -34,7 +34,7 @@ type UserDao = DaoData & {
 	iA: { BOOL: boolean };
 	d: { S: string };
 	lockerId?: { S: string };
-	cU?: { S: string };
+	cU?: { N: string };
 };
 
 type AccessTokenInfo = {


### PR DESCRIPTION
- `User.claimedUntil` 이 number 가 아닌 string 이었던 문제 수정
- API 문서에서 lockerId 의 층 첫부분에 0이 들어가 있던 문제 수정