### PR TITLE
학부별 설정의 날짜 값이 없을 경우 `null` 로 초기화하게 변경

### DIFF
--- a/packages/client/src/components/molecule/admin/department/DepartmentConfigSettings.svelte
+++ b/packages/client/src/components/molecule/admin/department/DepartmentConfigSettings.svelte
@@ -25,8 +25,8 @@
 	function initializeValues() {
 		id = original?.id ?? '';
 		name = original?.name ?? '';
-		activateFrom = original?.activateFrom ? new Date(original?.activateFrom) : undefined;
-		activateTo = original?.activateTo ? new Date(original?.activateTo) : undefined;
+		activateFrom = original?.activateFrom ? new Date(original?.activateFrom) : null;
+		activateTo = original?.activateTo ? new Date(original?.activateTo) : null;
 		contact = original?.contact ?? '';
 	}
 


### PR DESCRIPTION
- 기존 방식인 `undefined` 로 초기화 시 Svelte 에서 값이 초기화되지 않은 것으로 인식하고 오류 발생 가능성이 있음