### PR TITLE
사물함 그리드를 페이지에 맞게 y축 cetner설정, 잘못된 태그 수정, 스타일링

### DIFF
--- a/packages/client/src/components/molecule/reserve/LockerItem.svelte
+++ b/packages/client/src/components/molecule/reserve/LockerItem.svelte
@@ -25,19 +25,17 @@
     }
 
     .selected {
-        @apply border-8 border-blue-400;
+        @apply border-[3px] border-blue-400;
     }
-
     .selected > div {
         @apply text-blue-400;
     }
-
     .selected > .divide-line {
         @apply bg-blue-300;
     }
 
     .disabled {
-        @apply opacity-60 transition-all;
+        @apply opacity-60 bg-gray-100 transition-all;
     }
 
     .disabled:hover {

--- a/packages/client/src/components/molecule/reserve/LockerItem.svelte
+++ b/packages/client/src/components/molecule/reserve/LockerItem.svelte
@@ -3,13 +3,13 @@
   export let lockerNumber: number;
 </script>
 
-<div class="locker-item">
+<button class="locker-item">
   <div class="location-title">
       <p>{lockerLocation}</p><p>구역</p>
   </div>
   <div class="divide-line"></div>
   <div class="locker-number">{lockerNumber}</div>
-</div>
+</button>
 
 <style>
     .locker-item {

--- a/packages/client/src/components/molecule/reserve/LockerReserveInfo.svelte
+++ b/packages/client/src/components/molecule/reserve/LockerReserveInfo.svelte
@@ -43,7 +43,7 @@
 <style>
     .wrap {
         /* width: auto; 가 아닌 width: 100%; 라면 overflow 된 자식 요소의 크기를 따라간다?? */
-        @apply w-auto;
+        @apply w-auto h-screen flex flex-col;
     }
 
     /* -------------- 영역 선택 및 지도 -------------- */
@@ -90,7 +90,7 @@
 
     /* -------------- 사물함 그리드 영역 -------------- */
     .locker-grid-wrap {
-        @apply overflow-scroll;
+        @apply grow flex items-center overflow-scroll;
     }
 
     .locker-grid {


### PR DESCRIPTION
- 사물함 그리드를 y축 center에 맞도록 `wrap` 값을 `flex`로 지정
- `div` 태그를 `button`으로 변경
- `selected`, `disabled`상태에 따른 스타일링 변경