### PR TITLE
Collapse 할 수 있는 Navigation 영역

### DIFF
--- a/packages/client/src/components/atom/Divider.svelte
+++ b/packages/client/src/components/atom/Divider.svelte
@@ -3,10 +3,4 @@
 	export { clazz as class };
 </script>
 
-<hr class={clazz} />
-
-<style>
-    hr {
-        @apply w-full h-0.5 bg-gray-300;
-    }
-</style>
+<hr class='{clazz} w-full h-0.5 bg-gray-300' />

--- a/packages/client/src/components/atom/Divider.svelte
+++ b/packages/client/src/components/atom/Divider.svelte
@@ -1,0 +1,12 @@
+<script lang='ts'>
+	let clazz;
+	export { clazz as class };
+</script>
+
+<hr class={clazz} />
+
+<style>
+    hr {
+        @apply w-full h-0.5 bg-gray-300;
+    }
+</style>

--- a/packages/client/src/components/atom/NavigationCollapseButton.svelte
+++ b/packages/client/src/components/atom/NavigationCollapseButton.svelte
@@ -1,0 +1,20 @@
+<script lang='ts'>
+	import { getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import ChevronDown from '../../icons/ChevronDown.svelte';
+
+	let clazz = '';
+	export { clazz as class };
+
+	let { collapsed, set } = getContext<{ collapsed: Writable<boolean>, set: (isCollapsed: boolean) => void }>('Sidebar');
+
+</script>
+
+<button
+	class='{clazz} p-1 rounded-md hover:brightness-95 hover:backdrop-brightness-95 active:backdrop-brightness-75 active:brightness-75'
+	on:click={() => set(!$collapsed)}>
+	<ChevronDown class='transition-all{$collapsed ? " rotate-180" : ""}' />
+</button>
+
+<style>
+</style>

--- a/packages/client/src/components/atom/NavigationContent.svelte
+++ b/packages/client/src/components/atom/NavigationContent.svelte
@@ -1,0 +1,8 @@
+<script lang='ts'>
+	let clazz;
+	export { clazz as class };
+</script>
+
+<article class='{clazz} grow flex flex-col justify-start my-2'>
+	<slot />
+</article>

--- a/packages/client/src/components/atom/NavigationFooter.svelte
+++ b/packages/client/src/components/atom/NavigationFooter.svelte
@@ -1,0 +1,8 @@
+<script lang='ts'>
+	let clazz;
+	export { clazz as class };
+</script>
+
+<footer class='{clazz} py-4 flex flex-wrap justify-between'>
+	<slot />
+</footer>

--- a/packages/client/src/components/atom/NavigationHeader.svelte
+++ b/packages/client/src/components/atom/NavigationHeader.svelte
@@ -1,0 +1,8 @@
+<script lang='ts'>
+	let clazz;
+	export { clazz as class };
+</script>
+
+<header class='{clazz} flex flex-row justify-between'>
+	<slot />
+</header>

--- a/packages/client/src/components/atom/NavigationProfile.svelte
+++ b/packages/client/src/components/atom/NavigationProfile.svelte
@@ -1,0 +1,8 @@
+<script lang='ts'>
+	let clazz = '';
+	export { clazz as class };
+</script>
+
+<div class='{clazz} grow flex flex-col justify-end my-2'>
+	<slot />
+</div>

--- a/packages/client/src/components/molecule/Navigation.svelte
+++ b/packages/client/src/components/molecule/Navigation.svelte
@@ -1,0 +1,78 @@
+<script lang='ts'>
+	import { setContext } from 'svelte';
+	import { writable } from 'svelte/store';
+	import { fly } from 'svelte/transition';
+
+	let clazz = '';
+	export { clazz as class };
+
+	export let collapsable = false;
+
+	export let collapsed = true;
+
+	let collapsedState = writable<boolean>(collapsed);
+
+	export let navClass = '';
+	export let headerClass = '';
+
+	let h: number = 0;
+	let y: number = 0;
+	let oldY: number = 0;
+	let yDirection: number = 0;
+	let hideNavbar = false;
+
+	$: {
+		if (collapsed !== $collapsedState) {
+			collapsedState.set(collapsed);
+		}
+	}
+
+	$: {
+		const yDiff = y - oldY;
+		oldY = y;
+		calculateYDirection(yDiff);
+	}
+
+	function calculateYDirection(yDiff: number) {
+		if ((yDiff > 0 && yDirection < 0) || (yDiff < 0 && yDirection > 0)) yDirection = 0; else yDirection += yDiff;
+	}
+
+	$: isOnTop = y <= 80;
+
+	$: if (yDirection > 5) {
+		hideNavbar = true;
+	} else if (yDirection < -5) {
+		hideNavbar = false;
+	}
+
+	setContext('Sidebar', {
+		collapsed: collapsedState,
+		set: (isCollapsed: boolean) => {
+			collapsedState.set(isCollapsed);
+			collapsed = isCollapsed;
+		}
+	});
+</script>
+
+<svelte:window bind:scrollY={y} />
+{#if !collapsable || !hideNavbar || isOnTop || !collapsed}
+	<!-- fly animation 시 header 아래로 nav 가 expand 되도록 element 의 순서를 바꾸고 `flex-col-reverse` 를 적용 -->
+	<aside class='{clazz} flex flex-col-reverse max-h-screen z-50 overflow-y-auto'
+				 transition:fly={{ y: -100, duration: 500 }}
+				 class:absolute={collapsable && isOnTop}
+				 class:fixed={collapsable && !isOnTop}>
+		{#if !collapsable || !collapsed}
+			<nav transition:fly={{ y: -100, duration: 500 }}
+					 class='{navClass} px-10 flex flex-col bg-gray-200 grow overflow-y-scroll md:overflow-y-visible shadow-md'
+					 class:mb-2={collapsable}>
+				<slot />
+			</nav>
+		{/if}
+		<section bind:clientHeight={h} class='{headerClass} px-10 bg-gray-200 transition-all'
+						 class:shadow-md={collapsable && collapsed} class:mb-2={collapsable && collapsed}>
+			<slot name='header' />
+		</section>
+	</aside>
+{/if}
+
+<div style:margin-top={collapsable ? `${h}px` : '0'}></div>

--- a/packages/client/src/components/molecule/Navigation.svelte
+++ b/packages/client/src/components/molecule/Navigation.svelte
@@ -63,7 +63,7 @@
 				 class:fixed={collapsable && !isOnTop}>
 		{#if !collapsable || !collapsed}
 			<nav transition:fly={{ y: -100, duration: 500 }}
-					 class='{navClass} px-10 flex flex-col bg-gray-200 grow overflow-y-scroll md:overflow-y-visible shadow-md'
+					 class='{navClass} px-10 flex flex-col bg-gray-200 grow overflow-y-auto shadow-md'
 					 class:mb-2={collapsable}>
 				<slot />
 			</nav>

--- a/packages/client/src/components/molecule/Navigation.svelte
+++ b/packages/client/src/components/molecule/Navigation.svelte
@@ -21,10 +21,8 @@
 	let yDirection: number = 0;
 	let hideNavbar = false;
 
-	$: {
-		if (collapsed !== $collapsedState) {
-			collapsedState.set(collapsed);
-		}
+	$: if (collapsed !== $collapsedState) {
+		collapsedState.set(collapsed);
 	}
 
 	$: {

--- a/packages/client/src/components/molecule/Navigation.svelte
+++ b/packages/client/src/components/molecule/Navigation.svelte
@@ -57,7 +57,7 @@
 <svelte:window bind:scrollY={y} />
 {#if !collapsable || !hideNavbar || isOnTop || !collapsed}
 	<!-- fly animation 시 header 아래로 nav 가 expand 되도록 element 의 순서를 바꾸고 `flex-col-reverse` 를 적용 -->
-	<aside class='{clazz} flex flex-col-reverse max-h-screen z-50 overflow-y-auto'
+	<aside class='{clazz} flex flex-col-reverse justify-end max-h-screen z-50 overflow-y-auto'
 				 transition:fly={{ y: -100, duration: 500 }}
 				 class:absolute={collapsable && isOnTop}
 				 class:fixed={collapsable && !isOnTop}>


### PR DESCRIPTION
> 이슈 참고: #85

- Navigation 영역을 모바일에서 collapsable 하게 함으로써 레이아웃에 활용할 수 있습니다.
- `Navigation` 컴포넌트 아래에 `NavigationHeader`, `NavigationProfile`, `NavigationContent`, `NavigationFooter` 순으로 컴포넌트를 배치하면 하나의 네비게이션을 만들 수 있습니다.
- `NavigationCollapseButton` 을 `Navigation` 컴포넌트 아래에 아무 곳에나 배치하면 해당 버튼을 클릭하여 네비게이션을 열고 닫을 수 있습니다.

# `Navigation` 컴포넌트
## Properties
  - `collapsable` - 네비게이션을 열고 닫을 수 있는지 설정합니다. `collapsable` 이 참일 경우, 네비게이션은 스크롤되기 전에는 `absolute`, 스크롤된 후에는 `fixed` 포지션을 가집니다. `Navigation` 컴포넌트가 가로 뷰포트를 꽉 채울때에만 참으로 두는 것을 권장합니다.
- `collapsed` - 네비게이션이 열려 있는지 여부를 설정합니다. `reactive` 합니다.
- `class`
- `headerClass` - 네비게이션에서 collapse 되지 않는 헤더에 적용할 클래스를 설정합니다.
- `navClass` - 네비게이션에서 collapse 되는 부분에 적용할 클래스를 설정합니다.
## Slots
- `header` - 네비게이션에서 collapse 되지 않는 부분입니다. `NavigationHeader` 컴포넌트를 해당 영역에 넣는 것을 추천합니다.
