### PR TITLE
편리한 페이지 제목 설정을 위한 `PageTitle` 컴포넌트

### DIFF
--- a/packages/client/src/components/atom/PageTitle.svelte
+++ b/packages/client/src/components/atom/PageTitle.svelte
@@ -3,7 +3,7 @@
 
 	export let name: string;
 
-	$: serviceName = $config?.find((c: Config) => c.id === 'SERVICE').name ?? '사물함 시스템';
+	$: serviceName = ($config ?? []).find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 시스템';
 </script>
 
 <svelte:head>

--- a/packages/client/src/components/atom/PageTitle.svelte
+++ b/packages/client/src/components/atom/PageTitle.svelte
@@ -1,0 +1,11 @@
+<script lang='ts'>
+	import { config } from '$lib/store';
+
+	export let name: string;
+
+	$: serviceName = $config?.find((c: Config) => c.id === 'SERVICE').name ?? '사물함 시스템';
+</script>
+
+<svelte:head>
+	<title>{name ? `${name} - ` : ''}{serviceName}</title>
+</svelte:head>


### PR DESCRIPTION
> 이슈 참고: #87 
- `<PageTitle name='페이지 이름' />` 작성 시 페이지 이름이 변경됩니다.
- `name` 프로퍼티를 비우거나 작성하지 않을 경우 서비스 이름만 표기됩니다.