### PR TITLE
클라이언트 배포 시 `.html` 확장자 제거

### DIFF
--- a/packages/client/scripts/deploy.js
+++ b/packages/client/scripts/deploy.js
@@ -28,5 +28,46 @@ exec('aws cloudformation describe-stacks --stack-name ssu-it-locker', (err, stdo
 			return;
 		}
 		console.log(`${stdout}`);
+		console.log('File uploaded, renaming html...');
+		exec(`aws s3api list-objects --bucket ${s3Name}`, (err, stdout, stderr) => {
+			if (err) {
+				console.error(`Exception thrown: ${err.message}`);
+				return;
+			}
+			if (stderr) {
+				console.error(`Error occurred: ${stderr}`);
+				return;
+			}
+			const files = JSON.parse(stdout);
+			const contents = files['Contents'];
+			contents.forEach((content) => {
+				const key = content['Key'];
+				if (
+					key.endsWith('.html') &&
+					!key.endsWith('index.html') &&
+					!key.endsWith('400.html') &&
+					!key.endsWith('403.html') &&
+					!key.endsWith('404.html')
+				) {
+					exec(
+						`aws s3 mv s3://${s3Name}/${key} s3://${s3Name}/${key.substr(
+							0,
+							key.lastIndexOf('.html')
+						)}`,
+						(err, stdout, stderr) => {
+							if (err) {
+								console.error(`Exception thrown: ${err.message}`);
+								return;
+							}
+							if (stderr) {
+								console.error(`Error occurred: ${stderr}`);
+								return;
+							}
+							console.log(`${stdout}`);
+						}
+					);
+				}
+			});
+		});
 	});
 });


### PR DESCRIPTION
- 웹에서 S3 버킷에 액세스할 때 확장자를 포함한 파일 명이 정확히 일치 해야만 파일을 반환
- 따라서 자연스러운 액세스를 위해 `.html` 확장자를 제거
- `index.html` 과 `400.html`, `403.html`, `404.html` 의 경우 예약된 이름이므로 제거하지 않음.