### PR TITLE
존재하지 않는 사용자가 로그인 할 수 있는 오류 수정

### DIFF
--- a/packages/server/template.yaml
+++ b/packages/server/template.yaml
@@ -13,6 +13,9 @@ Parameters:
   AwsSamLocal:
     Type: String
     Default: ''
+  AdminId:
+    Type: String
+    Default: '20211561'
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
@@ -21,9 +24,7 @@ Globals:
       Variables:
         TABLE_NAME: !Ref TableName
         AWS_SAM_LOCAL: !Ref AwsSamLocal
-        ADMIN_ID:
-          Type: String
-          Default: '20211561'
+        ADMIN_ID: !Ref AdminId
 Conditions:
   IsSamLocal: !Equals
     - !Ref AwsSamLocal


### PR DESCRIPTION
- 존재하지 않는 사용자의 로그인을 막는 로직이 버그로 인해 무력화되었음
- 데이터가 없어 정상적인 작동은 불가능하지만, 로그인이 가능한 버그 존재