### PR TITLE
UI 레이아웃 구성 통합을 위한 `Shell` 및 `NavigationShell`

### DIFF
--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <Shell bind:navigationCollapsed bind:collapsable>
-	<Navigation slot='navigation' class='flex-row w-full md:min-w-[380px] md:w-[380px] md:basis-[380px] md:h-screen'
+	<Navigation slot='navigation' class='flex-row w-full h-full'
 							{collapsable} bind:collapsed={navigationCollapsed}>
 		<NavigationHeader class='md:pt-10' slot='header'>
 			<slot name='navigation_header'>

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -14,6 +14,12 @@
 	import Shell from './Shell.svelte';
 	import { fly } from 'svelte/transition';
 
+	let clazz = '';
+	export { clazz as class };
+
+	export let navigationClass = '';
+	export let mainClass = '';
+	
 	export let navigationCollapsed = true;
 
 	export let collapsable = true;
@@ -21,7 +27,7 @@
 	$: serviceName = ($config ?? []).find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 시스템';
 </script>
 
-<Shell bind:navigationCollapsed bind:collapsable>
+<Shell class={clazz} {navigationClass} {mainClass} bind:navigationCollapsed bind:collapsable>
 	<Navigation slot='navigation' class='flex-row w-full h-full'
 							{collapsable} bind:collapsed={navigationCollapsed}>
 		<NavigationHeader class='md:pt-10' slot='header'>

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -19,7 +19,7 @@
 
 	export let navigationClass = '';
 	export let mainClass = '';
-	
+
 	export let navigationCollapsed = true;
 
 	export let collapsable = true;
@@ -44,7 +44,6 @@
 		</NavigationHeader>
 		<p transition:fly={{ y: -20, duration: 200 }} class='font-semibold shrink'>{serviceName}</p>
 		<NavigationProfile>
-
 			<slot name='navigation_profile'>
 				<Profile user={$user} />
 			</slot>

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -1,0 +1,60 @@
+<script lang='ts'>
+	import Navigation from './Navigation.svelte';
+	import NavigationHeader from '../atom/NavigationHeader.svelte';
+	import Soongsil from '../../icons/Soongsil.svelte';
+	import NavigationProfile from '../atom/NavigationProfile.svelte';
+	import { config, user } from '$lib/store';
+	import Profile from '../../components/molecule/Profile.svelte';
+	import NavigationContent from '../atom/NavigationContent.svelte';
+	import NavigationFooter from '../atom/NavigationFooter.svelte';
+	import Divider from '../../components/atom/Divider.svelte';
+	import NavigationCollapseButton from '../atom/NavigationCollapseButton.svelte';
+	import Button from '../atom/Button.svelte';
+	import ArrowExportLtr from '../../icons/ArrowExportLtr.svelte';
+	import Shell from './Shell.svelte';
+	import { fly } from 'svelte/transition';
+
+	export let navigationCollapsed = true;
+
+	export let collapsable = true;
+
+	$: serviceName = ($config ?? []).find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 시스템';
+</script>
+
+<Shell bind:navigationCollapsed bind:collapsable>
+	<Navigation slot='navigation' class='flex-row w-full md:min-w-[380px] md:w-[380px] md:basis-[380px] md:h-screen'
+							{collapsable} bind:collapsed={navigationCollapsed}>
+		<NavigationHeader class='md:pt-10' slot='header'>
+			<slot name='navigation_header'>
+				<div class='flex flex-col grow items-start flex-wrap'>
+					<Soongsil class='w-20 h-20' />
+				</div>
+				{#if collapsable}
+					<div class='flex justify-center items-center'>
+						<NavigationCollapseButton />
+					</div>
+				{/if}
+			</slot>
+		</NavigationHeader>
+		<p transition:fly={{ y: -20, duration: 200 }} class='font-semibold shrink'>{serviceName}</p>
+		<NavigationProfile>
+
+			<slot name='navigation_profile'>
+				<Profile user={$user} />
+			</slot>
+		</NavigationProfile>
+		<Divider class='my-6' />
+		<NavigationContent>
+			<slot name='navigation_content' />
+		</NavigationContent>
+		<NavigationFooter>
+			<slot name='navigation_footer'>
+				<Button class='bg-primary-800 text-white' isIconRight={true} href='/logout'>
+					<ArrowExportLtr slot='icon' />
+					로그아웃
+				</Button>
+			</slot>
+		</NavigationFooter>
+	</Navigation>
+	<slot />
+</Shell>

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -5,27 +5,16 @@
 	import NavigationContent from '../atom/NavigationContent.svelte';
 	import NavigationFooter from '../atom/NavigationFooter.svelte';
 	import Divider from '../../components/atom/Divider.svelte';
-	import NavigationCollapseButton from '../atom/NavigationCollapseButton.svelte';
 	import Button from '../atom/Button.svelte';
 	import ArrowExportLtr from '../../icons/ArrowExportLtr.svelte';
-
-	export let navigationCollapsed = true;
-
-	export let collapsable = true;
 </script>
 
 <main class='flex flex-col md:flex-row items-stretch'>
 	<div class='flex flex row w-full md:min-w-[380px] md:basis-[380px] md:h-screen'>
 		<slot name='navigation'>
-			<Navigation class='flex-row w-full h-full'
-									{collapsable} bind:collapsed={navigationCollapsed}>
+			<Navigation class='flex-row w-full h-full'>
 				<NavigationHeader class='md:py-10' slot='header'>
 					<Soongsil class='w-20 h-20' />
-					{#if collapsable}
-						<div class='flex justify-center items-center'>
-							<NavigationCollapseButton />
-						</div>
-					{/if}
 				</NavigationHeader>
 				<Divider class='my-6' />
 				<NavigationContent>

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -7,10 +7,16 @@
 	import Divider from '../../components/atom/Divider.svelte';
 	import Button from '../atom/Button.svelte';
 	import ArrowExportLtr from '../../icons/ArrowExportLtr.svelte';
+
+	let clazz = '';
+	export { clazz as class };
+
+	export let navigationClass = '';
+	export let mainClass = '';
 </script>
 
-<main class='flex flex-col md:flex-row items-stretch'>
-	<div class='flex flex row w-full md:min-w-[380px] md:basis-[380px] md:h-screen'>
+<main class='{clazz} flex flex-col md:flex-row items-stretch'>
+	<section class='{navigationClass} flex flex row w-full md:min-w-[380px] md:basis-[380px] md:h-screen'>
 		<slot name='navigation'>
 			<Navigation class='flex-row w-full h-full'>
 				<NavigationHeader class='md:py-10' slot='header'>
@@ -27,8 +33,8 @@
 				</NavigationFooter>
 			</Navigation>
 		</slot>
-	</div>
-	<section class='grow md:max-h-screen overflow-x-scroll md:overflow-y-scroll'>
+	</section>
+	<section class='{mainClass} grow md:max-h-screen overflow-x-scroll md:overflow-y-scroll'>
 		<slot />
 	</section>
 </main>

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -1,0 +1,43 @@
+<script lang='ts'>
+	import Navigation from './Navigation.svelte';
+	import NavigationHeader from '../atom/NavigationHeader.svelte';
+	import Soongsil from '../../icons/Soongsil.svelte';
+	import NavigationContent from '../atom/NavigationContent.svelte';
+	import NavigationFooter from '../atom/NavigationFooter.svelte';
+	import Divider from '../../components/atom/Divider.svelte';
+	import NavigationCollapseButton from '../atom/NavigationCollapseButton.svelte';
+	import Button from '../atom/Button.svelte';
+	import ArrowExportLtr from '../../icons/ArrowExportLtr.svelte';
+
+	export let navigationCollapsed = true;
+
+	export let collapsable = true;
+</script>
+
+<main class='flex flex-col md:flex-row items-stretch'>
+	<slot name='navigation'>
+		<Navigation class='flex-row w-full md:min-w-[380px] md:w-[380px] md:basis-[380px] md:h-screen'
+								{collapsable} bind:collapsed={navigationCollapsed}>
+			<NavigationHeader class='md:py-10' slot='header'>
+				<Soongsil class='w-20 h-20' />
+				{#if collapsable}
+					<div class='flex justify-center items-center'>
+						<NavigationCollapseButton />
+					</div>
+				{/if}
+			</NavigationHeader>
+			<Divider class='my-6' />
+			<NavigationContent>
+			</NavigationContent>
+			<NavigationFooter>
+				<Button class='bg-primary-800 text-white' isIconRight={true} href='/logout'>
+					<ArrowExportLtr slot='icon' />
+					로그아웃
+				</Button>
+			</NavigationFooter>
+		</Navigation>
+	</slot>
+	<section class='grow md:max-h-screen overflow-x-scroll md:overflow-y-scroll'>
+		<slot />
+	</section>
+</main>

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -15,28 +15,30 @@
 </script>
 
 <main class='flex flex-col md:flex-row items-stretch'>
-	<slot name='navigation'>
-		<Navigation class='flex-row w-full md:min-w-[380px] md:w-[380px] md:basis-[380px] md:h-screen'
-								{collapsable} bind:collapsed={navigationCollapsed}>
-			<NavigationHeader class='md:py-10' slot='header'>
-				<Soongsil class='w-20 h-20' />
-				{#if collapsable}
-					<div class='flex justify-center items-center'>
-						<NavigationCollapseButton />
-					</div>
-				{/if}
-			</NavigationHeader>
-			<Divider class='my-6' />
-			<NavigationContent>
-			</NavigationContent>
-			<NavigationFooter>
-				<Button class='bg-primary-800 text-white' isIconRight={true} href='/logout'>
-					<ArrowExportLtr slot='icon' />
-					로그아웃
-				</Button>
-			</NavigationFooter>
-		</Navigation>
-	</slot>
+	<div class='flex flex row w-full md:min-w-[380px] md:basis-[380px] md:h-screen'>
+		<slot name='navigation'>
+			<Navigation class='flex-row w-full h-full'
+									{collapsable} bind:collapsed={navigationCollapsed}>
+				<NavigationHeader class='md:py-10' slot='header'>
+					<Soongsil class='w-20 h-20' />
+					{#if collapsable}
+						<div class='flex justify-center items-center'>
+							<NavigationCollapseButton />
+						</div>
+					{/if}
+				</NavigationHeader>
+				<Divider class='my-6' />
+				<NavigationContent>
+				</NavigationContent>
+				<NavigationFooter>
+					<Button class='bg-primary-800 text-white' isIconRight={true} href='/logout'>
+						<ArrowExportLtr slot='icon' />
+						로그아웃
+					</Button>
+				</NavigationFooter>
+			</Navigation>
+		</slot>
+	</div>
 	<section class='grow md:max-h-screen overflow-x-scroll md:overflow-y-scroll'>
 		<slot />
 	</section>


### PR DESCRIPTION
- `Shell` 컴포넌트와 `NavigationShell` 컴포넌트 작성
# `Shell` 컴포넌트
사물함 시스템에서 사용하는 기본적인 2분할 레이아웃을 표현함
- `md` breakpoint 이상 시 분할됨
- `md` 미만에서는 분할되지 않고 상 -> 하 레이아웃
- 분할 시 왼쪽이 네비게이션 영역, 오른쪽이 메인 영역임
- `navigation` 슬롯의 경우 좌우 분할시 최대 길이 380px

## Properties
- `class`
- `navigationClass` - 네비게이션 영역에 적용되는 CSS 클래스
- `mainClass` - 메인 영역에 적용되는 CSS 클래스

## Slots
- `navigation` - 네비게이션 영역 내부

# `NavigationShell` 컴포넌트
`Shell` 컴포넌트에서 `Navigation` 컴포넌트를 포함하여 편리한 레이아웃 표현

## Properties
- `class`
- `navigationClass` - 왼쪽 네비게이션 영역에 적용되는 CSS 클래스
- `mainClass` - 오른쪽 메인 영역에 적용되는 CSS 클래스
- `navigationCollapsed` - 네비게이션이 접혀 있는지 여부
- `collapsable` - 네비게이션을 접을 수 있는지 여부

## Slots
- `navigation_header` - `NavigationHeader` 내부(기본값: 숭실 로고 및 `NavigationCollapseButton`)
- `navigation_profile` - `NavigationProfile` 내부(기본값: `Profile` 컴포넌트)
- `navigation_content` - `NavigationContent`, 주 네비게이션 컨텐츠
- `navigation_footer` - `NavigationFooter` 내부(기본값: 로그아웃 버튼)