### PR TITLE
`NavigationShell` 이 작은 화면에서 메인 콘텐츠 영역을 덮는 문제 수정

### DIFF
--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <Shell class={clazz} {navigationClass} {mainClass} bind:navigationCollapsed bind:collapsable>
-	<Navigation slot='navigation' class='flex-row w-full h-full'
+	<Navigation slot='navigation' class='flex-row w-full'
 							{collapsable} bind:collapsed={navigationCollapsed}>
 		<NavigationHeader class='md:pt-10' slot='header'>
 			<slot name='navigation_header'>

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <main class='{clazz} flex flex-col md:flex-row items-stretch'>
-	<section class='{navigationClass} flex flex row w-full md:min-w-[380px] md:basis-[380px] md:h-screen'>
+	<section class='{navigationClass} flex row w-full md:min-w-[380px] md:basis-[380px] md:h-screen'>
 		<slot name='navigation'>
 			<Navigation class='flex-row w-full h-full'>
 				<NavigationHeader class='md:py-10' slot='header'>


### PR DESCRIPTION
- 실제로 보이진 않지만 이 영역으로 인해 메인 콘텐츠 영역과 상호작용이 불가능했음