### PR TITLE
BREAKING CHANGE: 백엔드 오류 처리 개선

### DIFF
--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -641,14 +641,22 @@ components:
       required:
         - success
         - error
-        - errorDescription
       properties:
         success:
           type: boolean
           default: false
         error:
-          type: integer
-          format: int32
+          type: object
+          required:
+            - code
+            - name
+          properties:
+            code:
+              type: number
+            name:
+              type: string
+            description:
+              type: string
         errorDescription:
           type: string
     AccessTokenInfo:

--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -59,7 +59,7 @@ paths:
                 error:
                   code: 401
                   name: 'Unauthorized'
-                  description: 'No result parameter provided'
+                  message: 'No result parameter provided'
         '403':
           description: 현재 로그인 불가할 경우
           content:
@@ -71,7 +71,7 @@ paths:
                 error:
                   code: 403
                   name: 'Blocked'
-                  description: 'Service unavailable'
+                  message: 'Service unavailable'
   /auth/logout:
     get:
       tags:
@@ -106,7 +106,7 @@ paths:
                 error:
                   code: 401
                   name: 'Unauthorized'
-                  description: 'Can''t logout when not logged in'
+                  message: 'Can''t logout when not logged in'
   /locker/query:
     get:
       tags:
@@ -149,7 +149,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
         '404':
           description: 사물함을 찾을 수 없을 경우
           content:
@@ -161,7 +161,7 @@ paths:
                 error:
                   code: 404
                   name: 'NotFound'
-                  description: 'Cannot find lockers'
+                  message: 'Cannot find lockers'
   /locker/count:
     get:
       tags:
@@ -194,7 +194,7 @@ paths:
                 error:
                   code: 404
                   name: 'NotFound'
-                  description: 'Cannot find lockers'
+                  message: 'Cannot find lockers'
   /locker/claim:
     post:
       tags:
@@ -239,7 +239,7 @@ paths:
                 error:
                   code: 400
                   name: 'BadRequest'
-                  description: 'Key "until" is must be an number'
+                  message: 'Key "until" is must be an number'
         '403':
           description: '현재 대여가 불가능하거나 사물함이 이미 대여된 경우'
           content:
@@ -254,7 +254,7 @@ paths:
                     error:
                       code: 403
                       name: 'Blocked'
-                      description: ''
+                      message: ''
                 Forbidden:
                   description: '현재 대여가 불가능할 경우'
                   value:
@@ -262,7 +262,7 @@ paths:
                     error:
                       code: 403
                       name: 'Forbidden'
-                      description: ''
+                      message: ''
                 Permission:
                   description: '권한 부족'
                   value:
@@ -270,7 +270,7 @@ paths:
                       error:
                         code: 403
                         name: 'Forbidden'
-                        description: 'Sufficient permission'
+                        message: 'Sufficient permission'
                 CantClaim:
                   description: '대여가 불가능한 사물함일 경우'
                   value:
@@ -278,7 +278,7 @@ paths:
                     error:
                       code: 403
                       name: 'CantClaim'
-                      description: 'Requested locker is already claimed'
+                      message: 'Requested locker is already claimed'
         '500':
           description: 사물함 정보를 찾을 수 없을 경우
           content:
@@ -290,7 +290,7 @@ paths:
                 error:
                   code: 500
                   name: 'InternalError'
-                  description: 'Unknown locker data'
+                  message: 'Unknown locker data'
   /locker/unclaim:
     post:
       tags:
@@ -331,7 +331,7 @@ paths:
                     error:
                       code: 403
                       name: 'Blocked'
-                      description: ''
+                      message: ''
                 Permission:
                   description: '권한 부족'
                   value:
@@ -339,7 +339,7 @@ paths:
                       error:
                         code: 403
                         name: 'Forbidden'
-                        description: 'Sufficient permission'
+                        message: 'Sufficient permission'
                 Forbidden:
                   description: '현재 대여가 불가능할 경우'
                   value:
@@ -347,7 +347,7 @@ paths:
                     error:
                       code: 403
                       name: 'Forbidden'
-                      description: ''
+                      message: ''
                 CantClaim:
                   description: '점유한 사물함이 없을 경우'
                   value:
@@ -355,7 +355,7 @@ paths:
                     error:
                       code: 403
                       name: 'CantClaim'
-                      description: 'This user is not claimed an locker yet'
+                      message: 'This user is not claimed an locker yet'
   /user:
     get:
       tags:
@@ -396,7 +396,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
         '404':
           description: 사용자를 찾을 수 없을 경우
           content:
@@ -408,7 +408,7 @@ paths:
                 error:
                   code: 404
                   name: 'NotFound'
-                  description: 'Cannot find user info of id 20220000'
+                  message: 'Cannot find user info of id 20220000'
   /user/update:
     post:
       tags:
@@ -448,7 +448,7 @@ paths:
                 error:
                   code: 400
                   name: 'BadRequest'
-                  description: 'Request body is malformed JSON'
+                  message: 'Request body is malformed JSON'
         '403':
           description: 권한 부족
             content:
@@ -460,7 +460,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
   /user/delete:
     post:
       tags:
@@ -500,7 +500,7 @@ paths:
                 error:
                   code: 400
                   name: 'BadRequest'
-                  description: 'Request body is malformed JSON'
+                  message: 'Request body is malformed JSON'
         '403':
           description: 권한 부족
             content:
@@ -512,7 +512,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
   /user/query:
     get:
       tags:
@@ -554,7 +554,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
         '404':
           description: 사용자를 찾을 수 없을 경우
           content:
@@ -566,7 +566,7 @@ paths:
                 error:
                   code: 404
                   name: 'NotFound'
-                  description: 'Cannot find user'
+                  message: 'Cannot find user'
   /user/batch/put:
     post:
       tags:
@@ -606,7 +606,7 @@ paths:
                 error:
                   code: 400
                   name: 'BadRequest'
-                  description: 'Request body is malformed JSON'
+                  message: 'Request body is malformed JSON'
         '403':
           description: 권한 부족
             content:
@@ -618,7 +618,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
   /user/batch/delete:
     post:
       tags:
@@ -658,7 +658,7 @@ paths:
                 error:
                   code: 400
                   name: 'BadRequest'
-                  description: 'Request body is malformed JSON'
+                  message: 'Request body is malformed JSON'
         '403':
           description: 권한 부족
             content:
@@ -670,7 +670,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
   /config:
     get:
       tags:
@@ -708,7 +708,7 @@ paths:
                 error:
                   code: 404
                   name: 'NotFound'
-                  description: 'Cannot find user'
+                  message: 'Cannot find user'
   /config/update:
     post:
       tags:
@@ -748,7 +748,7 @@ paths:
                 error:
                   code: 400
                   name: 'BadRequest'
-                  description: 'Request body is malformed JSON'
+                  message: 'Request body is malformed JSON'
         '403':
           description: 권한 부족
             content:
@@ -760,7 +760,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
   /config/delete:
     post:
       tags:
@@ -800,7 +800,7 @@ paths:
                 error:
                   code: 400
                   name: 'BadRequest'
-                  description: 'Request body is malformed JSON'
+                  message: 'Request body is malformed JSON'
         '403':
           description: 권한 부족
             content:
@@ -812,7 +812,7 @@ paths:
                   error:
                     code: 403
                     name: 'Forbidden'
-                    description: 'Sufficient permission'
+                    message: 'Sufficient permission'
 components:
   securitySchemes:
     UserLoginAuth:
@@ -853,7 +853,7 @@ components:
               type: number
             name:
               type: string
-            description:
+            message:
               type: string
     AccessTokenInfo:
       title: AccessTokenInfo

--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -56,8 +56,22 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 401
-                errorDescription: Unauthorized
+                error:
+                  code: 401
+                  name: 'Unauthorized'
+                  description: 'No result parameter provided'
+        '403':
+          description: 현재 로그인 불가할 경우
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                error:
+                  code: 403
+                  name: 'Blocked'
+                  description: 'Service unavailable'
   /auth/logout:
     get:
       tags:
@@ -89,8 +103,10 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 401
-                errorDescription: Unauthorized
+                error:
+                  code: 401
+                  name: 'Unauthorized'
+                  description: 'Can''t logout when not logged in'
   /locker/query:
     get:
       tags:
@@ -122,26 +138,30 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Locker'
-        '500':
-          description: 내부 오류 / department 없이 요청을 수행할 경우
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
+        '404':
+          description: 사물함을 찾을 수 없을 경우
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
-        '401':
-          description: 로그인 상태가 아닐 경우
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                success: false
-                error: 401
-                errorDescription: Unauthorized
+                error:
+                  code: 404
+                  name: 'NotFound'
+                  description: 'Cannot find lockers'
   /locker/count:
     get:
       tags:
@@ -163,16 +183,18 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/LockerCountResponse'
-        '500':
-          description: 내부 오류
+        '404':
+          description: 사물함을 찾을 수 없을 경우
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 404
+                  name: 'NotFound'
+                  description: 'Cannot find lockers'
   /locker/claim:
     post:
       tags:
@@ -206,26 +228,69 @@ paths:
                     properties:
                       lockerId:
                         type: string
+        '400':
+          description: '`until` 값이 올바르지 않을 경우'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                error:
+                  code: 400
+                  name: 'BadRequest'
+                  description: 'Key "until" is must be an number'
         '403':
-          description: 사물함이 이미 점유되었을 경우
+          description: '현재 대여가 불가능하거나 사물함이 이미 대여된 경우'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              example:
-                success: false
-                error: 403
-                errorDescription: Can't claim the locker that already reserved
+              examples:
+                Blocked:
+                  description: '서비스 중단으로 인해 현재 대여가 불가능할 경우'
+                  value:
+                    success: false
+                    error:
+                      code: 403
+                      name: 'Blocked'
+                      description: ''
+                Forbidden:
+                  description: '현재 대여가 불가능할 경우'
+                  value:
+                    success: false
+                    error:
+                      code: 403
+                      name: 'Forbidden'
+                      description: ''
+                Permission:
+                  description: '권한 부족'
+                  value:
+                    success: false
+                      error:
+                        code: 403
+                        name: 'Forbidden'
+                        description: 'Sufficient permission'
+                CantClaim:
+                  description: '대여가 불가능한 사물함일 경우'
+                  value:
+                    success: false
+                    error:
+                      code: 403
+                      name: 'CantClaim'
+                      description: 'Requested locker is already claimed'
         '500':
-          description: 내부 오류
+          description: 사물함 정보를 찾을 수 없을 경우
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 500
+                  name: 'InternalError'
+                  description: 'Unknown locker data'
   /locker/unclaim:
     post:
       tags:
@@ -253,25 +318,44 @@ paths:
                       lockerId:
                         type: string
         '403':
-          description: 점유한 사물함이 없을 경우
+          description: '현재 대여가 불가능하거나 사물함이 이미 대여된 경우'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              example:
-                success: false
-                error: 403
-                errorDescription: This user is not claimed an locker yet
-        '500':
-          description: 내부 오류
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-              example:
-                success: false
-                error: 500
-                errorDescription: Internal error
+              examples:
+                Blocked:
+                  description: '서비스 중단으로 인해 현재 대여가 불가능할 경우'
+                  value:
+                    success: false
+                    error:
+                      code: 403
+                      name: 'Blocked'
+                      description: ''
+                Permission:
+                  description: '권한 부족'
+                  value:
+                    success: false
+                      error:
+                        code: 403
+                        name: 'Forbidden'
+                        description: 'Sufficient permission'
+                Forbidden:
+                  description: '현재 대여가 불가능할 경우'
+                  value:
+                    success: false
+                    error:
+                      code: 403
+                      name: 'Forbidden'
+                      description: ''
+                CantClaim:
+                  description: '점유한 사물함이 없을 경우'
+                  value:
+                    success: false
+                    error:
+                      code: 403
+                      name: 'CantClaim'
+                      description: 'This user is not claimed an locker yet'
   /user:
     get:
       tags:
@@ -301,16 +385,30 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/User'
-        '500':
-          description: 내부 오류
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
+        '404':
+          description: 사용자를 찾을 수 없을 경우
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 404
+                  name: 'NotFound'
+                  description: 'Cannot find user info of id 20220000'
   /user/update:
     post:
       tags:
@@ -339,16 +437,30 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/UserUpdateRequest'
-        '500':
-          description: 내부 오류
+        '400':
+          description: 요청 형식이 잘못되었을 때
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 400
+                  name: 'BadRequest'
+                  description: 'Request body is malformed JSON'
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
   /user/delete:
     post:
       tags:
@@ -377,16 +489,30 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/UserDeleteRequest'
-        '500':
-          description: 내부 오류
+        '400':
+          description: 요청 형식이 잘못되었을 때
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 400
+                  name: 'BadRequest'
+                  description: 'Request body is malformed JSON'
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
   /user/query:
     get:
       tags:
@@ -417,16 +543,30 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/User'
-        '500':
-          description: 내부 오류 / department 값이 주어지지 않았을 때
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
+        '404':
+          description: 사용자를 찾을 수 없을 경우
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 404
+                  name: 'NotFound'
+                  description: 'Cannot find user'
   /user/batch/put:
     post:
       tags:
@@ -455,16 +595,30 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/UserBatchPutRequest'
-        '500':
-          description: 내부 오류
+        '400':
+          description: 요청 형식이 잘못되었을 때
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 400
+                  name: 'BadRequest'
+                  description: 'Request body is malformed JSON'
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
   /user/batch/delete:
     post:
       tags:
@@ -493,16 +647,30 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/UserBatchDeleteRequest'
-        '500':
-          description: 내부 오류
+        '400':
+          description: 요청 형식이 잘못되었을 때
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 400
+                  name: 'BadRequest'
+                  description: 'Request body is malformed JSON'
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
   /config:
     get:
       tags:
@@ -529,16 +697,18 @@ paths:
                     properties:
                       SERVICE:
                         $ref: '#/components/schemas/Config'
-        '500':
-          description: 내부 오류
+        '404':
+          description: 설정을 찾을 수 없을 경우
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 404
+                  name: 'NotFound'
+                  description: 'Cannot find user'
   /config/update:
     post:
       tags:
@@ -567,16 +737,30 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/ConfigUpdateRequest'
-        '500':
-          description: 내부 오류
+        '400':
+          description: 요청 형식이 잘못되었을 때
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 400
+                  name: 'BadRequest'
+                  description: 'Request body is malformed JSON'
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
   /config/delete:
     post:
       tags:
@@ -605,16 +789,30 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/ConfigDeleteRequest'
-        '500':
-          description: 내부 오류
+        '400':
+          description: 요청 형식이 잘못되었을 때
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 success: false
-                error: 500
-                errorDescription: Internal error
+                error:
+                  code: 400
+                  name: 'BadRequest'
+                  description: 'Request body is malformed JSON'
+        '403':
+          description: 권한 부족
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ErrorResponse'
+                example:
+                  success: false
+                  error:
+                    code: 403
+                    name: 'Forbidden'
+                    description: 'Sufficient permission'
 components:
   securitySchemes:
     UserLoginAuth:
@@ -657,8 +855,6 @@ components:
               type: string
             description:
               type: string
-        errorDescription:
-          type: string
     AccessTokenInfo:
       title: AccessTokenInfo
       description: 로그인 성공 시 발급되는 엑세스 토큰의 정보입니다.

--- a/packages/server/src/auth/data.ts
+++ b/packages/server/src/auth/data.ts
@@ -1,10 +1,12 @@
 import type {
 	ExpressionAttributeValueMap,
 	GetItemInput,
-	UpdateItemInput
+	UpdateItemInput,
+	UpdateItemOutput
 } from 'aws-sdk/clients/dynamodb';
-import { UnauthorizedError } from '../util/error';
+import { ForbiddenError, UnauthorizedError } from '../util/error';
 import { adminId, dynamoDB, TableName } from '../util/database';
+import type { AWSError } from 'aws-sdk';
 
 /* ISSUE/REVOKE TOKEN */
 
@@ -25,7 +27,15 @@ export const revokeToken = async function (
 		},
 		ReturnValues: 'UPDATED_OLD'
 	};
-	const res = await dynamoDB.updateItem(req).promise();
+	let res: UpdateItemOutput;
+	try {
+		res = await dynamoDB.updateItem(req).promise();
+	} catch (e) {
+		if ((e as AWSError).name === 'ConditionalCheckFailedException') {
+			throw new ForbiddenError('Cannot logout when token is invalid');
+		}
+		throw e;
+	}
 	if (res.Attributes.hasOwnProperty('aT')) {
 		return { accessToken: token };
 	} else {
@@ -62,13 +72,21 @@ export const issueToken = async function (
 			':expiresOn': { N: `${expires}` },
 			...(id !== adminId && conditionValues)
 		},
-		ReturnValues: 'UPDATED_NEW'
+		ReturnValues: 'ALL_NEW'
 	};
-	const res = await dynamoDB.updateItem(req).promise();
-	if (res.Attributes.hasOwnProperty('aT')) {
+	let res: UpdateItemOutput;
+	try {
+		res = await dynamoDB.updateItem(req).promise();
+	} catch (e) {
+		if ((e as AWSError).name === 'ConditionalCheckFailedException') {
+			throw new ForbiddenError('This user cannot login to service');
+		}
+		throw e;
+	}
+	if (res.Attributes.hasOwnProperty('aT') && res.Attributes.aT.S === token) {
 		return { id, expires };
 	} else {
-		throw new UnauthorizedError('Unauthorized', { id, expires });
+		throw new ForbiddenError('Cannot issue token', { id, expires });
 	}
 };
 
@@ -92,7 +110,7 @@ export async function assertAccessible(
 		authRes.Item.aT?.S !== token ||
 		(adminOnly && authRes.Item.iA?.BOOL !== true && id !== adminId)
 	) {
-		throw new UnauthorizedError('Unauthorized');
+		throw new UnauthorizedError('Sufficient permission');
 	}
 	return true;
 }

--- a/packages/server/src/auth/data.ts
+++ b/packages/server/src/auth/data.ts
@@ -110,7 +110,7 @@ export async function assertAccessible(
 		authRes.Item.aT?.S !== token ||
 		(adminOnly && authRes.Item.iA?.BOOL !== true && id !== adminId)
 	) {
-		throw new UnauthorizedError('Sufficient permission');
+		throw new ForbiddenError('Sufficient permission');
 	}
 	return true;
 }

--- a/packages/server/src/auth/handler/logout.ts
+++ b/packages/server/src/auth/handler/logout.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { assertAccessible, revokeToken } from '../data';
 import { createResponse } from '../../common';
-import { responseAsResponsibleError, UnauthorizedError } from '../../util/error';
+import { responseAsLockerError, UnauthorizedError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const logoutHandler: APIGatewayProxyHandler = async (event) => {
@@ -12,9 +12,6 @@ export const logoutHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await revokeToken(payload.aud as string, token);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsResponsibleError(
-			e,
-			new UnauthorizedError("Can't logout when not logged in", { token })
-		);
+		responseAsLockerError(e, new UnauthorizedError("Can't logout when not logged in", { token }));
 	}
 };

--- a/packages/server/src/auth/handler/ssu_login.ts
+++ b/packages/server/src/auth/handler/ssu_login.ts
@@ -1,8 +1,7 @@
 import https from 'https';
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
-import { createResponse } from '../../common';
+import { createResponse, JWT_SECRET } from '../../common';
 import {
 	BlockedError,
 	errorResponse,

--- a/packages/server/src/auth/handler/ssu_login.ts
+++ b/packages/server/src/auth/handler/ssu_login.ts
@@ -5,7 +5,7 @@ import { createResponse, JWT_SECRET } from '../../common';
 import {
 	BlockedError,
 	errorResponse,
-	responseAsResponsibleError,
+	responseAsLockerError,
 	UnauthorizedError
 } from '../../util/error';
 import { issueToken } from '../data';
@@ -69,6 +69,6 @@ export const ssuLoginHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return errorResponse(new UnauthorizedError('No result parameter provided'));
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/common.ts
+++ b/packages/server/src/common.ts
@@ -1,5 +1,7 @@
 import type { APIGatewayProxyHandler, APIGatewayProxyResult } from 'aws-lambda';
 
+export const JWT_SECRET = process.env.JWT_SECRET ?? 'this-is-sample-secret-key';
+
 export function createResponse(statusCode: number, body: string | object): APIGatewayProxyResult {
 	const stringifyBody = typeof body === 'string' ? body : JSON.stringify(body);
 	const res: APIGatewayProxyResult = {

--- a/packages/server/src/common.ts
+++ b/packages/server/src/common.ts
@@ -1,6 +1,5 @@
 import type { APIGatewayProxyHandler, APIGatewayProxyResult } from 'aws-lambda';
 
-
 export function createResponse(statusCode: number, body: string | object): APIGatewayProxyResult {
 	const stringifyBody = typeof body === 'string' ? body : JSON.stringify(body);
 	const res: APIGatewayProxyResult = {
@@ -15,7 +14,6 @@ export function createResponse(statusCode: number, body: string | object): APIGa
 	}
 	return res;
 }
-
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const localCorsHandler: APIGatewayProxyHandler = async () => {

--- a/packages/server/src/config/data.ts
+++ b/packages/server/src/config/data.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// noinspection JSUnusedLocalSymbols
+
 import type {
 	DeleteItemInput,
 	ExpressionAttributeNameMap,

--- a/packages/server/src/config/handler/delete.ts
+++ b/packages/server/src/config/handler/delete.ts
@@ -1,11 +1,9 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { deleteConfig } from '../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { verifyPayload } from '../../util/access';
 
 export const deleteConfigHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
@@ -13,49 +11,20 @@ export const deleteConfigHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		data = JSON.parse(event.body) as UserDeleteRequest;
 	} catch {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Data body is malformed JSON'
-		});
+		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
 	if (!data || !data.id) {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		});
-	}
-	let payload: JwtPayload;
-	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-	} catch {
-		console.debug('malformed token');
-		return createResponse(401, {
-			success: false,
-			error: 401,
-			errorDescription: 'Unauthorized'
-		});
+		return errorResponse(new BadRequestError('Request body does not contains id field'));
 	}
 	try {
+		const payload = verifyPayload(token);
 		const id = payload.aud as string;
 		await assertAccessible(id, token, true);
 		if (data.id.toUpperCase() === 'SERVICE')
-			return errorResponse(
-				new ResponsibleError(500, 'Internal error', "Can't delete SERVICE config.")
-			);
+			return errorResponse(new BadRequestError("Can't delete SERVICE config."));
 		const res = await deleteConfig(data.id);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			return errorResponse(e as ResponsibleError);
-		}
-		console.error(e);
-		const res = {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		};
-		return createResponse(500, res);
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/config/handler/delete.ts
+++ b/packages/server/src/config/handler/delete.ts
@@ -2,7 +2,7 @@ import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { deleteConfig } from '../data';
-import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { BadRequestError, errorResponse, responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const deleteConfigHandler: APIGatewayProxyHandler = async (event) => {
@@ -25,6 +25,6 @@ export const deleteConfigHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await deleteConfig(data.id);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/config/handler/get.ts
+++ b/packages/server/src/config/handler/get.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { queryConfig } from '../data';
-import { responseAsResponsibleError } from '../../util/error';
+import { responseAsLockerError } from '../../util/error';
 
 export const getConfigHandler: APIGatewayProxyHandler = async () => {
 	try {
@@ -11,6 +11,6 @@ export const getConfigHandler: APIGatewayProxyHandler = async () => {
 			result: configs
 		});
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/config/handler/get.ts
+++ b/packages/server/src/config/handler/get.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { queryConfig } from '../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import { responseAsResponsibleError } from '../../util/error';
 
 export const getConfigHandler: APIGatewayProxyHandler = async (event) => {
 	try {
@@ -11,14 +11,6 @@ export const getConfigHandler: APIGatewayProxyHandler = async (event) => {
 			result: configs
 		});
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			return errorResponse(e as ResponsibleError);
-		}
-		return createResponse(200, {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		});
+		responseAsResponsibleError(e);
 	}
-
 };

--- a/packages/server/src/config/handler/get.ts
+++ b/packages/server/src/config/handler/get.ts
@@ -3,7 +3,7 @@ import { createResponse } from '../../common';
 import { queryConfig } from '../data';
 import { responseAsResponsibleError } from '../../util/error';
 
-export const getConfigHandler: APIGatewayProxyHandler = async (event) => {
+export const getConfigHandler: APIGatewayProxyHandler = async () => {
 	try {
 		const configs = await queryConfig();
 		return createResponse(200, {

--- a/packages/server/src/config/handler/update.ts
+++ b/packages/server/src/config/handler/update.ts
@@ -2,7 +2,7 @@ import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { updateConfig } from '../data';
-import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { BadRequestError, errorResponse, responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const updateConfigHandler: APIGatewayProxyHandler = async (event) => {
@@ -23,6 +23,6 @@ export const updateConfigHandler: APIGatewayProxyHandler = async (event) => {
 		await updateConfig(data);
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/config/handler/update.ts
+++ b/packages/server/src/config/handler/update.ts
@@ -1,57 +1,28 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { updateConfig } from '../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { verifyPayload } from '../../util/access';
 
 export const updateConfigHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
 	let data: ConfigUpdateRequest;
 	try {
-		data = JSON.parse(event.body) as ConfigUpdateRequest;
+		data = JSON.parse(event.body) as UserDeleteRequest;
 	} catch {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Data body is malformed JSON'
-		});
+		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
 	if (!data || !data.id) {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		});
-	}
-	let payload: JwtPayload;
-	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-	} catch {
-		console.debug('malformed token');
-		return createResponse(401, {
-			success: false,
-			error: 401,
-			errorDescription: 'Unauthorized'
-		});
+		return errorResponse(new BadRequestError('Request body does not contains id field'));
 	}
 	try {
+		const payload = verifyPayload(token);
 		const id = payload.aud as string;
 		await assertAccessible(id, token, true);
 		await updateConfig(data);
 		return createResponse(200, { success: true });
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			return errorResponse(e as ResponsibleError);
-		}
-		console.error(e);
-		const res = {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		};
-		return createResponse(500, res);
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -1,2 +1,1 @@
-export const JWT_SECRET =
-	'this-is-sample-secret-key';
+export const JWT_SECRET = 'this-is-sample-secret-key';

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -1,1 +1,0 @@
-export const JWT_SECRET = 'this-is-sample-secret-key';

--- a/packages/server/src/locker/data.ts
+++ b/packages/server/src/locker/data.ts
@@ -6,7 +6,7 @@ import type {
 	UpdateItemOutput
 } from 'aws-sdk/clients/dynamodb';
 import { adminId, dynamoDB, TableName } from '../util/database';
-import { CantClaimError, ForbiddenError, NotFoundError, UnauthorizedError } from '../util/error';
+import { CantClaimError, ForbiddenError, NotFoundError } from '../util/error';
 import type { AWSError } from 'aws-sdk';
 
 export const claimLocker = async function (

--- a/packages/server/src/locker/handler/claim.ts
+++ b/packages/server/src/locker/handler/claim.ts
@@ -9,7 +9,7 @@ import {
 	errorResponse,
 	ForbiddenError,
 	InternalError,
-	responseAsResponsibleError
+	responseAsLockerError
 } from '../../util/error';
 import { adminId } from '../../util/database';
 import { getBlockedDepartments, verifyPayload } from '../../util/access';
@@ -59,6 +59,6 @@ export const claimLockerHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/claim.ts
+++ b/packages/server/src/locker/handler/claim.ts
@@ -1,14 +1,18 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { claimLocker } from '../data';
 import { getUser } from '../../user/data';
 import { isValidLocker } from '../../util/locker';
 import { queryConfig } from '../../config/data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import {
+	BadRequestError,
+	errorResponse,
+	ForbiddenError,
+	InternalError,
+	responseAsResponsibleError
+} from '../../util/error';
 import { adminId } from '../../util/database';
+import { getBlockedDepartments, verifyPayload } from '../../util/access';
 
 export const claimLockerHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
@@ -19,79 +23,42 @@ export const claimLockerHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		data = JSON.parse(event.body) as { lockerId: string; until?: number };
 	} catch {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Data body is malformed JSON'
-		});
+		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
-	let payload: JwtPayload;
 	if (!data.lockerId) {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Key "locker_id" is must be given'
-		});
+		return errorResponse(new BadRequestError('Key "locker_id" is must be given'));
 	}
-
 	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
+		const payload = verifyPayload(token);
 		const id = payload.aud as string;
 		const user = await getUser(id);
-		const config = await queryConfig();
-		const blockedDepartments = config
-			.filter((c) => {
-				const activateFrom = new Date(c.activateFrom);
-				const activateTo = new Date(c.activateTo);
-				return (
-					(c.activateFrom && activateFrom.getTime() > Date.now()) ||
-					(c.activateTo && activateTo.getTime() < Date.now())
-				);
-			})
-			.map((c) => c.id);
-		if (adminId !== id && blockedDepartments.includes('SERVICE')) {
-			return createResponse(403, {
-				success: false,
-				error: 403,
-				errorDescription: 'Forbidden'
-			});
+		const configs = await queryConfig();
+		const serviceConfig: ServiceConfig = configs.find(
+			(c: Config) => c.id === 'SERVICE'
+		) as ServiceConfig;
+		if (!serviceConfig) {
+			return errorResponse(new InternalError('Cannot find available lockers'));
 		}
-		if (
-			!isValidLocker(
-				config.find((v) => v.id === 'SERVICE') as ServiceConfig,
-				data.lockerId,
-				user.department
-			)
-		) {
-			return createResponse(500, {
-				success: false,
-				error: 500,
-				errorDescription: 'Unknown locker data'
-			});
+		const blockedDepartments = getBlockedDepartments(configs);
+		if (adminId !== id && blockedDepartments.includes('SERVICE')) {
+			return errorResponse(new ForbiddenError());
+		}
+		if (!isValidLocker(serviceConfig, data.lockerId, user.department)) {
+			return errorResponse(new InternalError('Unknown locker data'));
 		}
 		if (data.until !== undefined && typeof data.until !== 'number') {
-			return createResponse(500, {
-				success: false,
-				error: 500,
-				errorDescription: 'Key "until" is must be number'
-			});
+			return errorResponse(new BadRequestError('Key "until" is must be an number'));
 		}
 		const lockerId = data.lockerId;
 		const until = data?.until;
-		const res = until
-			? await claimLocker(id, token, blockedDepartments, lockerId, until)
-			: await claimLocker(id, token, blockedDepartments, lockerId);
+		let res: { id: string; lockerId: string; claimedUntil: number };
+		if (until) {
+			res = await claimLocker(id, token, blockedDepartments, lockerId, until);
+		} else {
+			res = await claimLocker(id, token, blockedDepartments, lockerId);
+		}
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		if (!isResponsibleError(e)) {
-			console.error(e);
-			const res = {
-				success: false,
-				error: 500,
-				errorDescription: 'Internal error'
-			};
-			return createResponse(500, res);
-		}
-		return errorResponse(e as ResponsibleError);
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/locker/handler/count.ts
+++ b/packages/server/src/locker/handler/count.ts
@@ -3,21 +3,26 @@ import { queryLockers } from '../data';
 import { createResponse } from '../../common';
 import { getLockerDepartment } from '../../util/locker';
 import { getConfig } from '../../config/data';
+import { responseAsResponsibleError } from '../../util/error';
 
 export const getClaimedLockerCountHandler: APIGatewayProxyHandler = async () => {
-	const config = (await getConfig('SERVICE')) as ServiceConfig;
-	const lockers = await queryLockers();
-	const result = lockers.reduce<LockerCountResponse>((acc, cur) => {
-		const dept = getLockerDepartment(config, cur.lockerId);
-		const parsedLockerId = cur.lockerId.split('-');
-		const lockerFloor = parsedLockerId[1];
-		if (!acc[dept]) acc[dept] = {};
-		if (typeof acc[dept][lockerFloor] !== 'number') acc[dept][lockerFloor] = 0;
-		acc[getLockerDepartment(config, cur.lockerId)][lockerFloor] += 1;
-		return acc;
-	}, {});
-	return createResponse(200, {
-		success: true,
-		result
-	});
+	try {
+		const config = (await getConfig('SERVICE')) as ServiceConfig;
+		const lockers = await queryLockers();
+		const result = lockers.reduce<LockerCountResponse>((acc, cur) => {
+			const dept = getLockerDepartment(config, cur.lockerId);
+			const parsedLockerId = cur.lockerId.split('-');
+			const lockerFloor = parsedLockerId[1];
+			if (!acc[dept]) acc[dept] = {};
+			if (typeof acc[dept][lockerFloor] !== 'number') acc[dept][lockerFloor] = 0;
+			acc[getLockerDepartment(config, cur.lockerId)][lockerFloor] += 1;
+			return acc;
+		}, {});
+		return createResponse(200, {
+			success: true,
+			result
+		});
+	} catch (e) {
+		responseAsResponsibleError(e);
+	}
 };

--- a/packages/server/src/locker/handler/count.ts
+++ b/packages/server/src/locker/handler/count.ts
@@ -3,7 +3,7 @@ import { queryLockers } from '../data';
 import { createResponse } from '../../common';
 import { getLockerDepartment } from '../../util/locker';
 import { getConfig } from '../../config/data';
-import { responseAsResponsibleError } from '../../util/error';
+import { responseAsLockerError } from '../../util/error';
 
 export const getClaimedLockerCountHandler: APIGatewayProxyHandler = async () => {
 	try {
@@ -23,6 +23,6 @@ export const getClaimedLockerCountHandler: APIGatewayProxyHandler = async () => 
 			result
 		});
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/query.ts
+++ b/packages/server/src/locker/handler/query.ts
@@ -3,7 +3,7 @@ import { createResponse } from '../../common';
 import { queryLockers } from '../data';
 import { assertAccessible } from '../../auth/data';
 import { verifyPayload } from '../../util/access';
-import { responseAsResponsibleError } from '../../util/error';
+import { responseAsLockerError } from '../../util/error';
 
 export const queryClaimedLockersHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
@@ -18,6 +18,6 @@ export const queryClaimedLockersHandler: APIGatewayProxyHandler = async (event) 
 			result
 		});
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/query.ts
+++ b/packages/server/src/locker/handler/query.ts
@@ -1,29 +1,23 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { createResponse } from '../../common';
 import { queryLockers } from '../data';
 import { assertAccessible } from '../../auth/data';
+import { verifyPayload } from '../../util/access';
+import { responseAsResponsibleError } from '../../util/error';
 
 export const queryClaimedLockersHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
 	const showId = event.queryStringParameters?.show_id === 'true';
-	let id: string;
 	try {
-		const payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-		id = payload.aud as string;
-	} catch {
-		return createResponse(401, {
-			success: false,
-			error: 401,
-			errorDescription: 'Unauthorized'
+		const payload = verifyPayload(token);
+		const id = payload.aud as string;
+		await assertAccessible(id, token, showId);
+		const result = await queryLockers('', showId);
+		return createResponse(200, {
+			success: true,
+			result
 		});
+	} catch (e) {
+		responseAsResponsibleError(e);
 	}
-	await assertAccessible(id, token, showId);
-	const result = await queryLockers('', showId);
-	return createResponse(200, {
-		success: true,
-		result
-	});
 };

--- a/packages/server/src/locker/handler/unclaim.ts
+++ b/packages/server/src/locker/handler/unclaim.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { unclaimLocker } from '../data';
-import { BlockedError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { BlockedError, errorResponse, responseAsLockerError } from '../../util/error';
 import { queryConfig } from '../../config/data';
 import { adminId } from '../../util/database';
 import { getBlockedDepartments, verifyPayload } from '../../util/access';
@@ -19,6 +19,6 @@ export const unclaimLockerHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await unclaimLocker(id, token, blockedDepartments);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/unclaim.ts
+++ b/packages/server/src/locker/handler/unclaim.ts
@@ -1,49 +1,24 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { unclaimLocker } from '../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import { BlockedError, errorResponse, responseAsResponsibleError } from '../../util/error';
 import { queryConfig } from '../../config/data';
 import { adminId } from '../../util/database';
+import { getBlockedDepartments, verifyPayload } from '../../util/access';
 
 export const unclaimLockerHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
-	let payload: JwtPayload;
 	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
+		const payload = verifyPayload(token);
 		const id = payload.aud as string;
-		const config = await queryConfig();
-		const blockedDepartments = config
-			.filter((c) => {
-				const activateFrom = new Date(c.activateFrom);
-				const activateTo = new Date(c.activateTo);
-				return (
-					(c.activateFrom && activateFrom.getTime() > Date.now()) ||
-					(c.activateTo && activateTo.getTime() < Date.now())
-				);
-			})
-			.map((c) => c.id);
+		const configs = await queryConfig();
+		const blockedDepartments = getBlockedDepartments(configs);
 		if (adminId !== id && blockedDepartments.includes('SERVICE')) {
-			return createResponse(403, {
-				success: false,
-				error: 403,
-				errorDescription: 'Forbidden'
-			});
+			return errorResponse(new BlockedError('Service unavailable'));
 		}
 		const res = await unclaimLocker(id, token, blockedDepartments);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		if (!isResponsibleError(e)) {
-			console.error(e);
-			const res = {
-				success: false,
-				error: 500,
-				errorDescription: 'Internal error'
-			};
-			return createResponse(500, res);
-		}
-		return errorResponse(e as ResponsibleError);
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/user/data.ts
+++ b/packages/server/src/user/data.ts
@@ -162,7 +162,7 @@ export const batchPutUser = async function (infos: Array<User>): Promise<Array<U
 		RequestItems: {}
 	};
 	req.RequestItems[TableName] = requests;
-	const res = await dynamoDB.batchWriteItem(req).promise();
+	await dynamoDB.batchWriteItem(req).promise();
 	return infos;
 };
 
@@ -185,6 +185,6 @@ export const batchDeleteUser = async function (ids: Array<string>): Promise<Arra
 		RequestItems: {}
 	};
 	req.RequestItems[TableName] = requests;
-	const res = await dynamoDB.batchWriteItem(req).promise();
+	await dynamoDB.batchWriteItem(req).promise();
 	return ids;
 };

--- a/packages/server/src/user/handler/batch/delete.ts
+++ b/packages/server/src/user/handler/batch/delete.ts
@@ -1,11 +1,17 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../../env';
 import { createResponse } from '../../../common';
 import { assertAccessible } from '../../../auth/data';
 import { batchDeleteUser } from '../../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../../util/error';
+import {
+	BadRequestError,
+	errorResponse,
+	InternalError,
+	isResponsibleError,
+	responseAsResponsibleError,
+	ResponsibleError
+} from '../../../util/error';
+import { verifyPayload } from '../../../util/access';
 
 export const batchDeleteUserHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
@@ -13,29 +19,16 @@ export const batchDeleteUserHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		data = JSON.parse(event.body) as string[];
 	} catch {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Data body is malformed JSON'
-		});
+		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
 	if (!data || !Array.isArray(data)) {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		});
+		return errorResponse(new BadRequestError('Request body is not an array'));
 	}
 	let payload: JwtPayload;
 	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-	} catch {
-		console.debug('malformed token');
-		return createResponse(401, {
-			success: false,
-			error: 401,
-			errorDescription: 'Unauthorized'
-		});
+		payload = verifyPayload(token);
+	} catch (e) {
+		return responseAsResponsibleError(e);
 	}
 	let i = 0;
 	try {
@@ -48,16 +41,14 @@ export const batchDeleteUserHandler: APIGatewayProxyHandler = async (event) => {
 		return createResponse(200, { success: true });
 	} catch (e) {
 		if (isResponsibleError(e)) {
-			(e as ResponsibleError).additionalInfo.failed_data = data.slice(i, data.length);
+			(e as ResponsibleError).additionalInfo.failedData = data.slice(i, data.length);
 			return errorResponse(e as ResponsibleError);
 		}
 		console.error(e);
-		const res = {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error',
-			failed_data: JSON.stringify(data.slice(i, data.length))
-		};
-		return createResponse(500, res);
+		return errorResponse(
+			new InternalError('Internal error', {
+				failedData: JSON.stringify(data.slice(i, data.length))
+			})
+		);
 	}
 };

--- a/packages/server/src/user/handler/batch/delete.ts
+++ b/packages/server/src/user/handler/batch/delete.ts
@@ -7,9 +7,7 @@ import {
 	BadRequestError,
 	errorResponse,
 	InternalError,
-	isResponsibleError,
-	responseAsResponsibleError,
-	ResponsibleError
+	responseAsResponsibleError
 } from '../../../util/error';
 import { verifyPayload } from '../../../util/access';
 
@@ -40,15 +38,8 @@ export const batchDeleteUserHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true });
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			(e as ResponsibleError).additionalInfo.failedData = data.slice(i, data.length);
-			return errorResponse(e as ResponsibleError);
-		}
-		console.error(e);
-		return errorResponse(
-			new InternalError('Internal error', {
-				failedData: JSON.stringify(data.slice(i, data.length))
-			})
-		);
+		responseAsResponsibleError(e, new InternalError('Internal error'), {
+			failedData: JSON.stringify(data.slice(i, data.length))
+		});
 	}
 };

--- a/packages/server/src/user/handler/batch/delete.ts
+++ b/packages/server/src/user/handler/batch/delete.ts
@@ -7,7 +7,7 @@ import {
 	BadRequestError,
 	errorResponse,
 	InternalError,
-	responseAsResponsibleError
+	responseAsLockerError
 } from '../../../util/error';
 import { verifyPayload } from '../../../util/access';
 
@@ -26,7 +26,7 @@ export const batchDeleteUserHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		payload = verifyPayload(token);
 	} catch (e) {
-		return responseAsResponsibleError(e);
+		return responseAsLockerError(e);
 	}
 	let i = 0;
 	try {
@@ -38,7 +38,7 @@ export const batchDeleteUserHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsResponsibleError(e, new InternalError('Internal error'), {
+		responseAsLockerError(e, new InternalError('Internal error'), {
 			failedData: JSON.stringify(data.slice(i, data.length))
 		});
 	}

--- a/packages/server/src/user/handler/batch/put.ts
+++ b/packages/server/src/user/handler/batch/put.ts
@@ -1,11 +1,17 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../../env';
 import { createResponse } from '../../../common';
 import { assertAccessible } from '../../../auth/data';
 import { batchPutUser } from '../../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../../util/error';
+import {
+	BadRequestError,
+	errorResponse,
+	InternalError,
+	isResponsibleError,
+	responseAsResponsibleError,
+	ResponsibleError
+} from '../../../util/error';
+import { verifyPayload } from '../../../util/access';
 
 export const batchPutUserHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
@@ -13,29 +19,16 @@ export const batchPutUserHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		data = JSON.parse(event.body) as User[];
 	} catch {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Data body is malformed JSON'
-		});
+		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
 	if (!data || !Array.isArray(data)) {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		});
+		return errorResponse(new BadRequestError('Request body is not an array'));
 	}
 	let payload: JwtPayload;
 	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-	} catch {
-		console.debug('malformed token');
-		return createResponse(401, {
-			success: false,
-			error: 401,
-			errorDescription: 'Unauthorized'
-		});
+		payload = verifyPayload(token);
+	} catch (e) {
+		return responseAsResponsibleError(e);
 	}
 	let i = 0;
 	try {
@@ -48,16 +41,14 @@ export const batchPutUserHandler: APIGatewayProxyHandler = async (event) => {
 		return createResponse(200, { success: true });
 	} catch (e) {
 		if (isResponsibleError(e)) {
-			(e as ResponsibleError).additionalInfo.failed_data = data.slice(i, data.length);
+			(e as ResponsibleError).additionalInfo.failedData = data.slice(i, data.length);
 			return errorResponse(e as ResponsibleError);
 		}
 		console.error(e);
-		const res = {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error',
-			failed_data: JSON.stringify(data.slice(i, data.length))
-		};
-		return createResponse(500, res);
+		return errorResponse(
+			new InternalError('Internal error', {
+				failedData: JSON.stringify(data.slice(i, data.length))
+			})
+		);
 	}
 };

--- a/packages/server/src/user/handler/batch/put.ts
+++ b/packages/server/src/user/handler/batch/put.ts
@@ -7,9 +7,7 @@ import {
 	BadRequestError,
 	errorResponse,
 	InternalError,
-	isResponsibleError,
-	responseAsResponsibleError,
-	ResponsibleError
+	responseAsResponsibleError
 } from '../../../util/error';
 import { verifyPayload } from '../../../util/access';
 
@@ -40,15 +38,8 @@ export const batchPutUserHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true });
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			(e as ResponsibleError).additionalInfo.failedData = data.slice(i, data.length);
-			return errorResponse(e as ResponsibleError);
-		}
-		console.error(e);
-		return errorResponse(
-			new InternalError('Internal error', {
-				failedData: JSON.stringify(data.slice(i, data.length))
-			})
-		);
+		responseAsResponsibleError(e, new InternalError('Internal error'), {
+			failedData: JSON.stringify(data.slice(i, data.length))
+		});
 	}
 };

--- a/packages/server/src/user/handler/batch/put.ts
+++ b/packages/server/src/user/handler/batch/put.ts
@@ -7,7 +7,7 @@ import {
 	BadRequestError,
 	errorResponse,
 	InternalError,
-	responseAsResponsibleError
+	responseAsLockerError
 } from '../../../util/error';
 import { verifyPayload } from '../../../util/access';
 
@@ -26,7 +26,7 @@ export const batchPutUserHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		payload = verifyPayload(token);
 	} catch (e) {
-		return responseAsResponsibleError(e);
+		return responseAsLockerError(e);
 	}
 	let i = 0;
 	try {
@@ -38,7 +38,7 @@ export const batchPutUserHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsResponsibleError(e, new InternalError('Internal error'), {
+		responseAsLockerError(e, new InternalError('Internal error'), {
 			failedData: JSON.stringify(data.slice(i, data.length))
 		});
 	}

--- a/packages/server/src/user/handler/delete.ts
+++ b/packages/server/src/user/handler/delete.ts
@@ -1,11 +1,9 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { deleteUser } from '../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { verifyPayload } from '../../util/access';
 
 export const deleteUserHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
@@ -13,45 +11,18 @@ export const deleteUserHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		data = JSON.parse(event.body) as UserDeleteRequest;
 	} catch {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Data body is malformed JSON'
-		});
+		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
 	if (!data || !data.id) {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		});
-	}
-	let payload: JwtPayload;
-	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-	} catch {
-		console.debug('malformed token');
-		return createResponse(401, {
-			success: false,
-			error: 401,
-			errorDescription: 'Unauthorized'
-		});
+		return errorResponse(new BadRequestError('Request body must contains "id" field'));
 	}
 	try {
+		const payload = verifyPayload(token);
 		const id = payload.aud as string;
 		await assertAccessible(id, token, true);
 		const res = await deleteUser(data.id);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			return errorResponse(e as ResponsibleError);
-		}
-		console.error(e);
-		const res = {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		};
-		return createResponse(500, res);
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/user/handler/delete.ts
+++ b/packages/server/src/user/handler/delete.ts
@@ -2,7 +2,7 @@ import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { deleteUser } from '../data';
-import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { BadRequestError, errorResponse, responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const deleteUserHandler: APIGatewayProxyHandler = async (event) => {
@@ -23,6 +23,6 @@ export const deleteUserHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await deleteUser(data.id);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/handler/get.ts
+++ b/packages/server/src/user/handler/get.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { getUser } from '../data';
-import { responseAsResponsibleError } from '../../util/error';
+import { responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const getUserHandler: APIGatewayProxyHandler = async (event) => {
@@ -14,6 +14,6 @@ export const getUserHandler: APIGatewayProxyHandler = async (event) => {
 			result
 		});
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/handler/get.ts
+++ b/packages/server/src/user/handler/get.ts
@@ -1,37 +1,19 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { createResponse } from '../../common';
 import { getUser } from '../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import { responseAsResponsibleError } from '../../util/error';
+import { verifyPayload } from '../../util/access';
 
 export const getUserHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
 	try {
-		const id = (jwt.verify(token, JWT_SECRET) as JwtPayload).aud as string;
+		const id = verifyPayload(token).aud as string;
 		const result = await getUser(id);
 		return createResponse(200, {
 			success: true,
 			result
 		});
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			return errorResponse(e as ResponsibleError);
-		}
-		if (e instanceof JsonWebTokenError || e instanceof TokenExpiredError) {
-			return createResponse(401, {
-				success: false,
-				error: 401,
-				description: 'Unauthorized'
-			});
-		}
-		console.error(e);
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			description: 'Internal Error'
-		});
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/user/handler/query.ts
+++ b/packages/server/src/user/handler/query.ts
@@ -5,7 +5,7 @@ import { JWT_SECRET } from '../../env';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { queryUser } from '../data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import { responseAsResponsibleError } from '../../util/error';
 
 export const queryUserHandler: APIGatewayProxyHandler = async (event) => {
 	const startsWith = event.queryStringParameters?.starts ?? '';
@@ -19,14 +19,6 @@ export const queryUserHandler: APIGatewayProxyHandler = async (event) => {
 			result
 		});
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			return errorResponse(e as ResponsibleError);
-		}
-		console.error(e);
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			description: 'Internal Error'
-		});
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/user/handler/query.ts
+++ b/packages/server/src/user/handler/query.ts
@@ -2,7 +2,7 @@ import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { queryUser } from '../data';
-import { responseAsResponsibleError } from '../../util/error';
+import { responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const queryUserHandler: APIGatewayProxyHandler = async (event) => {
@@ -17,6 +17,6 @@ export const queryUserHandler: APIGatewayProxyHandler = async (event) => {
 			result
 		});
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/handler/query.ts
+++ b/packages/server/src/user/handler/query.ts
@@ -1,17 +1,15 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
 import { queryUser } from '../data';
 import { responseAsResponsibleError } from '../../util/error';
+import { verifyPayload } from '../../util/access';
 
 export const queryUserHandler: APIGatewayProxyHandler = async (event) => {
 	const startsWith = event.queryStringParameters?.starts ?? '';
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
 	try {
-		const id = (jwt.verify(token, JWT_SECRET) as JwtPayload).aud as string;
+		const id = verifyPayload(token).aud as string;
 		await assertAccessible(id, token, true);
 		const result = await queryUser(startsWith);
 		return createResponse(200, {

--- a/packages/server/src/user/handler/update.ts
+++ b/packages/server/src/user/handler/update.ts
@@ -2,13 +2,7 @@ import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { updateUser } from '../data';
 import { assertAccessible } from '../../auth/data';
-import {
-	BadRequestError,
-	errorResponse,
-	isResponsibleError,
-	responseAsResponsibleError,
-	ResponsibleError
-} from '../../util/error';
+import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const updateUserHandler: APIGatewayProxyHandler = async (event) => {

--- a/packages/server/src/user/handler/update.ts
+++ b/packages/server/src/user/handler/update.ts
@@ -2,7 +2,7 @@ import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { updateUser } from '../data';
 import { assertAccessible } from '../../auth/data';
-import { BadRequestError, errorResponse, responseAsResponsibleError } from '../../util/error';
+import { BadRequestError, errorResponse, responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
 export const updateUserHandler: APIGatewayProxyHandler = async (event) => {
@@ -23,6 +23,6 @@ export const updateUserHandler: APIGatewayProxyHandler = async (event) => {
 		await updateUser(data);
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsResponsibleError(e);
+		responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/handler/update.ts
+++ b/packages/server/src/user/handler/update.ts
@@ -1,11 +1,15 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
-import type { JwtPayload } from 'jsonwebtoken';
-import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../../env';
 import { updateUser } from '../data';
 import { assertAccessible } from '../../auth/data';
-import { errorResponse, isResponsibleError, ResponsibleError } from '../../util/error';
+import {
+	BadRequestError,
+	errorResponse,
+	isResponsibleError,
+	responseAsResponsibleError,
+	ResponsibleError
+} from '../../util/error';
+import { verifyPayload } from '../../util/access';
 
 export const updateUserHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
@@ -13,45 +17,18 @@ export const updateUserHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		data = JSON.parse(event.body) as UserUpdateRequest;
 	} catch {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Data body is malformed JSON'
-		});
+		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
 	if (!data || !data.id) {
-		return createResponse(500, {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		});
-	}
-	let payload: JwtPayload;
-	try {
-		payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
-	} catch {
-		console.debug('malformed token');
-		return createResponse(401, {
-			success: false,
-			error: 401,
-			errorDescription: 'Unauthorized'
-		});
+		return errorResponse(new BadRequestError('Request body must contains "id" field'));
 	}
 	try {
+		const payload = verifyPayload(token);
 		const id = payload.aud as string;
 		await assertAccessible(id, token, true);
 		await updateUser(data);
 		return createResponse(200, { success: true });
 	} catch (e) {
-		if (isResponsibleError(e)) {
-			return errorResponse(e as ResponsibleError);
-		}
-		console.error(e);
-		const res = {
-			success: false,
-			error: 500,
-			errorDescription: 'Internal error'
-		};
-		return createResponse(500, res);
+		responseAsResponsibleError(e);
 	}
 };

--- a/packages/server/src/util/access.ts
+++ b/packages/server/src/util/access.ts
@@ -1,7 +1,7 @@
 import type { JwtPayload } from 'jsonwebtoken';
 import * as jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '../env';
 import { UnauthorizedError } from './error';
+import { JWT_SECRET } from '../common';
 
 export const getBlockedDepartments = (configs: Config[]): Array<string> => {
 	return configs

--- a/packages/server/src/util/access.ts
+++ b/packages/server/src/util/access.ts
@@ -1,0 +1,25 @@
+import type { JwtPayload } from 'jsonwebtoken';
+import * as jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../env';
+import { UnauthorizedError } from './error';
+
+export const getBlockedDepartments = (configs: Config[]): Array<string> => {
+	return configs
+		.filter((c: Config) => {
+			const activateFrom = new Date(c.activateFrom);
+			const activateTo = new Date(c.activateTo);
+			return (
+				(c.activateFrom && activateFrom.getTime() > Date.now()) ||
+				(c.activateTo && activateTo.getTime() < Date.now())
+			);
+		})
+		.map<string>((c: Config) => c.id);
+};
+
+export const verifyPayload = (token: string): JwtPayload => {
+	try {
+		return jwt.verify(token, JWT_SECRET) as JwtPayload;
+	} catch {
+		throw new UnauthorizedError();
+	}
+};

--- a/packages/server/src/util/database.ts
+++ b/packages/server/src/util/database.ts
@@ -16,4 +16,3 @@ if (process.env.AWS_SAM_LOCAL) {
 }
 
 export const dynamoDB = new AWS.DynamoDB(options);
-

--- a/packages/server/src/util/error.ts
+++ b/packages/server/src/util/error.ts
@@ -1,102 +1,101 @@
 import type { APIGatewayProxyResult } from 'aws-lambda';
 import { createResponse } from '../common';
 
-export class ResponsibleError extends Error {
+export class LockerError extends Error {
+	isLockerError: true;
+
 	message: string;
 
-	errorCode: number;
+	code: number;
 
 	additionalInfo: Record<string, unknown>;
 
-	errorName: string;
+	name: string;
 
 	constructor(
-		errorCode: number,
-		errorName: string,
+		code: number,
+		name: string,
 		message?: string,
 		additionalInfo?: Record<string, unknown>
 	) {
 		super(message);
-		this.errorCode = errorCode;
-		this.errorName = errorName;
+		this.code = code;
+		this.name = name;
 		this.message = message;
 		this.additionalInfo = additionalInfo;
 	}
 }
 
-export class BadRequestError extends ResponsibleError {
+export class BadRequestError extends LockerError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(400, 'BadRequest', message, additionalInfo);
 	}
 }
 
-export class UnauthorizedError extends ResponsibleError {
+export class UnauthorizedError extends LockerError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(401, 'Unauthorized', message, additionalInfo);
 	}
 }
 
-export class ForbiddenError extends ResponsibleError {
+export class ForbiddenError extends LockerError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(403, 'Forbidden', message, additionalInfo);
 	}
 }
 
-export class BlockedError extends ResponsibleError {
+export class BlockedError extends LockerError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(403, 'Blocked', message, additionalInfo);
 	}
 }
 
-export class NotFoundError extends ResponsibleError {
+export class NotFoundError extends LockerError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(404, 'NotFound', message, additionalInfo);
 	}
 }
 
-export class CantClaimError extends ResponsibleError {
+export class CantClaimError extends LockerError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(403, 'CantClaim', message, additionalInfo);
 	}
 }
 
-export class InternalError extends ResponsibleError {
+export class InternalError extends LockerError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(500, 'InternalError', message, additionalInfo);
 	}
 }
 
-export function isResponsibleError(error: unknown) {
-	return typeof error === 'object' && Object.keys(error).includes('errorName');
+export function isLockerError(error: unknown) {
+	return typeof error === 'object' && (error as LockerError)?.isLockerError;
 }
 
-export function errorResponse(
-	error: ResponsibleError,
-	overrideDescription?: string
-): APIGatewayProxyResult {
-	return createResponse(error.errorCode, {
+export function errorResponse(error: LockerError, overrideMessage?: string): APIGatewayProxyResult {
+	return createResponse(error.code, {
 		success: false,
 		error: {
-			code: error.errorCode,
-			name: error.errorName,
-			description: overrideDescription ?? error.message,
+			code: error.code,
+			name: error.name,
+			message: overrideMessage ?? error.message,
 			...error.additionalInfo
 		}
 	});
 }
 
-export function responseAsResponsibleError(
+export function responseAsLockerError(
 	error: unknown,
-	fallback: ResponsibleError = new InternalError(),
+	fallback: LockerError = new InternalError(),
 	additionalInfo: Record<string, unknown> = {}
 ) {
-	if (isResponsibleError(error)) {
+	if (isLockerError(error)) {
 		if (additionalInfo)
-			(error as ResponsibleError).additionalInfo = {
-				...(error as ResponsibleError).additionalInfo,
+			(error as LockerError).additionalInfo = {
+				...(error as LockerError).additionalInfo,
 				...additionalInfo
 			};
-		return errorResponse(error as ResponsibleError);
+		return errorResponse(error as LockerError);
 	}
 	console.error(error);
 	if (additionalInfo) fallback.additionalInfo = { ...fallback.additionalInfo, ...additionalInfo };

--- a/packages/server/src/util/error.ts
+++ b/packages/server/src/util/error.ts
@@ -8,17 +8,17 @@ export class ResponsibleError extends Error {
 
 	additionalInfo: Record<string, unknown>;
 
-	errorType: string;
+	errorName: string;
 
 	constructor(
 		errorCode: number,
-		errorType: string,
+		errorName: string,
 		message?: string,
 		additionalInfo?: Record<string, unknown>
 	) {
 		super(message);
 		this.errorCode = errorCode;
-		this.errorType = errorType;
+		this.errorName = errorName;
 		this.message = message;
 		this.additionalInfo = additionalInfo;
 	}
@@ -27,6 +27,12 @@ export class ResponsibleError extends Error {
 export class UnauthorizedError extends ResponsibleError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
 		super(401, 'UnauthorizedError', message, additionalInfo);
+	}
+}
+
+export class ForbiddenError extends ResponsibleError {
+	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
+		super(403, 'ForbiddenError', message, additionalInfo);
 	}
 }
 
@@ -43,7 +49,7 @@ export class CantClaimError extends ResponsibleError {
 }
 
 export function isResponsibleError(error: unknown) {
-	return typeof error === 'object' && Object.keys(error).includes('errorType');
+	return typeof error === 'object' && Object.keys(error).includes('errorName');
 }
 
 export function errorResponse(
@@ -52,8 +58,11 @@ export function errorResponse(
 ): APIGatewayProxyResult {
 	return createResponse(error.errorCode, {
 		success: false,
-		error: error.errorCode,
-		errorDescription: overrideDescription ?? error.message,
-		...error.additionalInfo
+		error: {
+			code: error.errorCode,
+			name: error.errorName,
+			description: overrideDescription ?? error.message,
+			...error.additionalInfo
+		}
 	});
 }

--- a/packages/server/src/util/error.ts
+++ b/packages/server/src/util/error.ts
@@ -87,9 +87,18 @@ export function errorResponse(
 
 export function responseAsResponsibleError(
 	error: unknown,
-	fallback: ResponsibleError = new InternalError()
+	fallback: ResponsibleError = new InternalError(),
+	additionalInfo: Record<string, unknown> = {}
 ) {
-	if (isResponsibleError(error)) return errorResponse(error as ResponsibleError);
+	if (isResponsibleError(error)) {
+		if (additionalInfo)
+			(error as ResponsibleError).additionalInfo = {
+				...(error as ResponsibleError).additionalInfo,
+				...additionalInfo
+			};
+		return errorResponse(error as ResponsibleError);
+	}
 	console.error(error);
+	if (additionalInfo) fallback.additionalInfo = { ...fallback.additionalInfo, ...additionalInfo };
 	return errorResponse(fallback);
 }

--- a/packages/server/src/util/error.ts
+++ b/packages/server/src/util/error.ts
@@ -24,27 +24,45 @@ export class ResponsibleError extends Error {
 	}
 }
 
+export class BadRequestError extends ResponsibleError {
+	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
+		super(400, 'BadRequest', message, additionalInfo);
+	}
+}
+
 export class UnauthorizedError extends ResponsibleError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
-		super(401, 'UnauthorizedError', message, additionalInfo);
+		super(401, 'Unauthorized', message, additionalInfo);
 	}
 }
 
 export class ForbiddenError extends ResponsibleError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
-		super(403, 'ForbiddenError', message, additionalInfo);
+		super(403, 'Forbidden', message, additionalInfo);
+	}
+}
+
+export class BlockedError extends ResponsibleError {
+	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
+		super(403, 'Blocked', message, additionalInfo);
 	}
 }
 
 export class NotFoundError extends ResponsibleError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
-		super(404, 'NotFoundError', message, additionalInfo);
+		super(404, 'NotFound', message, additionalInfo);
 	}
 }
 
 export class CantClaimError extends ResponsibleError {
 	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
-		super(403, 'CantClaimError', message, additionalInfo);
+		super(403, 'CantClaim', message, additionalInfo);
+	}
+}
+
+export class InternalError extends ResponsibleError {
+	constructor(message?: string, additionalInfo?: Record<string, unknown>) {
+		super(500, 'InternalError', message, additionalInfo);
 	}
 }
 
@@ -65,4 +83,13 @@ export function errorResponse(
 			...error.additionalInfo
 		}
 	});
+}
+
+export function responseAsResponsibleError(
+	error: unknown,
+	fallback: ResponsibleError = new InternalError()
+) {
+	if (isResponsibleError(error)) return errorResponse(error as ResponsibleError);
+	console.error(error);
+	return errorResponse(fallback);
 }

--- a/packages/server/template.yaml
+++ b/packages/server/template.yaml
@@ -16,6 +16,9 @@ Parameters:
   AdminId:
     Type: String
     Default: '20211561'
+  JwtSecret:
+    Type: String
+    Default: 'this-is-sample-secret-key'
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
@@ -25,6 +28,7 @@ Globals:
         TABLE_NAME: !Ref TableName
         AWS_SAM_LOCAL: !Ref AwsSamLocal
         ADMIN_ID: !Ref AdminId
+        JWT_SECRET: !Ref JWT_SECRET
 Conditions:
   IsSamLocal: !Equals
     - !Ref AwsSamLocal

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -166,47 +166,47 @@ type SuccessResponse = {
 
 type ErrorResponse = {
 	success: false;
-	error: ResponsibleError;
+	error: LockerError;
 };
 
-type BadRequestError = ResponsibleError & {
+type BadRequestError = LockerError & {
 	code: 400;
 	name: 'BadRequest';
 };
 
-type UnauthorizedError = ResponsibleError & {
+type UnauthorizedError = LockerError & {
 	code: 401;
 	name: 'Unauthorized';
 };
 
-type ForbiddenError = ResponsibleError & {
+type ForbiddenError = LockerError & {
 	code: 403;
 	name: 'Forbidden';
 };
 
-type BlockedError = ResponsibleError & {
+type BlockedError = LockerError & {
 	code: 403;
 	name: 'Blocked';
 };
 
-type NotFoundError = ResponsibleError & {
+type NotFoundError = LockerError & {
 	code: 404;
 	name: 'NotFound';
 };
 
-type CantClaimError = ResponsibleError & {
+type CantClaimError = LockerError & {
 	code: 403;
 	name: 'CantClaim';
 };
 
-type InternalError = ResponsibleError & {
+type InternalError = LockerError & {
 	code: 500;
 	name: 'InternalError';
 };
 
 /* Error Definition */
 
-type ResponsibleError = {
+type LockerError = {
 	code: string;
 	name: string;
 	message?: string;

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -173,6 +173,62 @@ type ErrorResponse = {
 	};
 };
 
+type BadRequestErrorResponse = ErrorResponse & {
+	error: {
+		code: 400;
+		name: 'BadRequest';
+		description?: string;
+	};
+};
+
+type UnauthorizedErrorResponse = ErrorResponse & {
+	error: {
+		code: 401;
+		name: 'Unauthorized';
+		description?: string;
+	};
+};
+
+type ForbiddenErrorResponse = ErrorResponse & {
+	error: {
+		code: 403;
+		name: 'Forbidden';
+		description?: string;
+	};
+};
+
+type BlockedErrorResponse = ErrorResponse & {
+	error: {
+		code: 403;
+		name: 'Blocked';
+		description?: string;
+	};
+};
+
+type NotFoundErrorResponse = ErrorResponse & {
+	error: {
+		code: 404;
+		name: 'NotFound';
+		description?: string;
+	};
+};
+
+type CantClaimErrorResponse = ErrorResponse & {
+	error: {
+		code: 403;
+		name: 'CantClaim';
+		description?: string;
+	};
+};
+
+type InternalErrorResponse = ErrorResponse & {
+	error: {
+		code: 500;
+		name: 'InternalError';
+		description?: string;
+	};
+};
+
 /* Error Definition */
 
 type ResponsibleError = {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -166,15 +166,17 @@ type SuccessResponse = {
 
 type ErrorResponse = {
 	success: false;
-	error: number;
-	errorType: string;
-	errorDescription: string;
+	error: {
+		code: number;
+		name: string;
+		description?: string;
+	};
 };
 
 /* Error Definition */
 
 type ResponsibleError = {
-	errorType: string;
+	errorName: string;
 	message?: string;
 	additionalInfo?: Record<string, unknown>;
 };

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -153,6 +153,24 @@ type LockerCountResponse = {
 	};
 };
 
+/* Response Definition */
+
+type Response = {
+	success: boolean;
+};
+
+type SuccessResponse = {
+	success: true;
+	result?: unknown;
+};
+
+type ErrorResponse = {
+	success: false;
+	error: number;
+	errorType: string;
+	errorDescription: string;
+};
+
 /* Error Definition */
 
 type ResponsibleError = {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -166,73 +166,49 @@ type SuccessResponse = {
 
 type ErrorResponse = {
 	success: false;
-	error: {
-		code: number;
-		name: string;
-		description?: string;
-	};
+	error: ResponsibleError;
 };
 
-type BadRequestErrorResponse = ErrorResponse & {
-	error: {
-		code: 400;
-		name: 'BadRequest';
-		description?: string;
-	};
+type BadRequestError = ResponsibleError & {
+	code: 400;
+	name: 'BadRequest';
 };
 
-type UnauthorizedErrorResponse = ErrorResponse & {
-	error: {
-		code: 401;
-		name: 'Unauthorized';
-		description?: string;
-	};
+type UnauthorizedError = ResponsibleError & {
+	code: 401;
+	name: 'Unauthorized';
 };
 
-type ForbiddenErrorResponse = ErrorResponse & {
-	error: {
-		code: 403;
-		name: 'Forbidden';
-		description?: string;
-	};
+type ForbiddenError = ResponsibleError & {
+	code: 403;
+	name: 'Forbidden';
 };
 
-type BlockedErrorResponse = ErrorResponse & {
-	error: {
-		code: 403;
-		name: 'Blocked';
-		description?: string;
-	};
+type BlockedError = ResponsibleError & {
+	code: 403;
+	name: 'Blocked';
 };
 
-type NotFoundErrorResponse = ErrorResponse & {
-	error: {
-		code: 404;
-		name: 'NotFound';
-		description?: string;
-	};
+type NotFoundError = ResponsibleError & {
+	code: 404;
+	name: 'NotFound';
 };
 
-type CantClaimErrorResponse = ErrorResponse & {
-	error: {
-		code: 403;
-		name: 'CantClaim';
-		description?: string;
-	};
+type CantClaimError = ResponsibleError & {
+	code: 403;
+	name: 'CantClaim';
 };
 
-type InternalErrorResponse = ErrorResponse & {
-	error: {
-		code: 500;
-		name: 'InternalError';
-		description?: string;
-	};
+type InternalError = ResponsibleError & {
+	code: 500;
+	name: 'InternalError';
 };
 
 /* Error Definition */
 
 type ResponsibleError = {
-	errorName: string;
+	code: string;
+	name: string;
 	message?: string;
 	additionalInfo?: Record<string, unknown>;
 };


### PR DESCRIPTION
> 관련 이슈: #99 #153 

# 백엔드 오류 처리 변경사항
> **주의:** 아래 변경 사항을 꼭 확인하시고 리뷰처리 및 머지 해주세요

## `ErrorResponse` 의 형식 변경
기존의 `Response` 형식:
```json
{
  "success": false,
  "error": 400,
  "errorDescription": "Description"
}
```

변경된 형식:
```json
{
  "success": false,
  "error": {
    "code": 400,
    "name": "BadRequest",
    "message": "Description"
  }
}
```
`error` 의 자료형이 숫자에서 오브젝트로 변경 및 `errorDescription` 등 오류 정보는 모두 `error` 키 아래의 오브젝트에 포함됨.

`code` - `HTTP 상태 코드`

`name` - 오류 이름

`message`(선택) - 오류 설명

## 오류 Response 

모든 오류 Response는 `index.d.ts` 에 정의되어 있으며, `LockerError` 를 상속함.
클라이언트 단에서 오류 감지시 해당 자료형을 사용할 것
목록:
```
BadRequestError
UnauthorizedError
ForbiddenError
BlockedError
CantClaimError
NotFoundError
InternalError
```

# 추가 사항
`JWT_SECRET` 토큰을 환경변수로 받을 수 있도록 개선하고, `env.ts` 파일 삭제