### PR TITLE
BREAKING: `zod`를 활용한 Schema Validation, store 오류 핸들링

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,8 @@
     "tailwindcss": "^3.1.5",
     "tslib": "^2.3.1",
     "typescript": "^4.7.4",
-    "vite": "^3.0.0"
+    "vite": "^3.0.0",
+    "zod": "^3.18.0"
   },
   "type": "module",
   "dependencies": {

--- a/packages/client/src/components/atom/PageTitle.svelte
+++ b/packages/client/src/components/atom/PageTitle.svelte
@@ -3,7 +3,10 @@
 
 	export let name: string;
 
-	$: serviceName = ($config ?? []).find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 시스템';
+	let serviceName = '사물함 예약 시스템'
+	$: if ($config?.success) {
+		serviceName = ($config.result ?? []).find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 예약 시스템';
+	}
 </script>
 
 <svelte:head>

--- a/packages/client/src/components/atom/PageTitle.svelte
+++ b/packages/client/src/components/atom/PageTitle.svelte
@@ -4,7 +4,7 @@
 	export let name: string;
 
 	let serviceName = '사물함 예약 시스템'
-	$: if ($config?.success) {
+	$: if ($config && $config.success) {
 		serviceName = ($config.result ?? []).find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 예약 시스템';
 	}
 </script>

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -24,7 +24,11 @@
 
 	export let collapsable = true;
 
-	$: serviceName = ($config ?? []).find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 시스템';
+	let serviceName = '사물함 예약 시스템';
+
+	$: if ($config?.success) {
+		serviceName = $config.result.find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 예약 시스템';
+	}
 </script>
 
 <Shell class={clazz} {navigationClass} {mainClass} bind:navigationCollapsed bind:collapsable>

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -26,7 +26,7 @@
 
 	let serviceName = '사물함 예약 시스템';
 
-	$: if ($config?.success) {
+	$: if ($config && $config.success) {
 		serviceName = $config.result.find((c: Config) => c.id === 'SERVICE')?.name ?? '사물함 예약 시스템';
 	}
 </script>
@@ -49,7 +49,7 @@
 		<p transition:fly={{ y: -20, duration: 200 }} class='font-semibold shrink'>{serviceName}</p>
 		<NavigationProfile>
 			<slot name='navigation_profile'>
-				<Profile user={$user?.success ? $user.result : undefined} />
+				<Profile user={$user && $user.success ? $user.result : undefined} />
 			</slot>
 		</NavigationProfile>
 		<Divider class='my-6' />

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -49,7 +49,7 @@
 		<p transition:fly={{ y: -20, duration: 200 }} class='font-semibold shrink'>{serviceName}</p>
 		<NavigationProfile>
 			<slot name='navigation_profile'>
-				<Profile user={$user} />
+				<Profile user={$user?.success ? $user.result : undefined} />
 			</slot>
 		</NavigationProfile>
 		<Divider class='my-6' />

--- a/packages/client/src/components/molecule/Profile.svelte
+++ b/packages/client/src/components/molecule/Profile.svelte
@@ -7,15 +7,15 @@
 	export let user: User;
 </script>
 {#if user}
-	<div class='profile'>
+	<div class='flex flex-col items-start gap-1'>
 		<p>반갑습니다!</p>
-		<p><span class='name'>{user?.name ?? '알 수 없음'}</span>님</p>
-		<Tag class='bg-gray-300 text-gray-700'>학부 \ {getDepartmentNameById($config, user.department) ?? '알 수 없음'}</Tag>
+		<p><span class='text-5xl font-bold text-primary-800'>{user?.name ?? '알 수 없음'}</span>님</p>
+		<Tag class='bg-gray-300 text-gray-700'>학부 \ {getDepartmentNameById($config?.result ?? [], user.department) ?? '알 수 없음'}</Tag>
 		<Tag class='bg-gray-300 text-gray-700'>학번 \ {user.id}</Tag>
 	</div>
 {:else}
-	<div class='profile'>
-		<div class='skeleton-wrap gap-3'>
+	<div class='flex flex-col items-start gap-1'>
+		<div class='flex flex-row gap-3'>
 			<Skeleton class='w-20 h-20 rounded-full bg-gray-300' />
 			<div class='flex flex-col gap-2'>
 				<Skeleton class='w-28 h-7 rounded-lg bg-gray-300' />
@@ -26,21 +26,8 @@
 {/if}
 
 <style>
-
-    .profile {
-        @apply flex flex-col items-start gap-1;
-    }
-
-    p {
+		p {
         @apply font-semibold leading-5;
-    }
-
-    .name {
-        @apply text-5xl font-bold text-primary-800;
-    }
-
-    .skeleton-wrap {
-        @apply flex flex-row;
     }
 </style>
 

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -29,7 +29,7 @@
 		}
 	});
 
-	$: if (!disableBlock && !isReservable($config, $user, currentTime)) {
+	$: if ($config?.success && $user?.success && !disableBlock && !isReservable($config.result, $user.result, currentTime)) {
 		blockedModalOpen = true;
 	}
 
@@ -40,12 +40,12 @@
 		const serviceConfig: ServiceConfig = (config ?? []).find((c: Config) => c.id === 'SERVICE') as ServiceConfig;
 		const userDeptConfig: DepartmentConfig = (config ?? []).find((c: Config) => c.id === user.department) as DepartmentConfig;
 		if (serviceConfig) {
-			if (serviceConfig.activateFrom && new Date(serviceConfig.activateFrom).getTime() > time.getTime()) return false;
-			if (serviceConfig.activateTo && new Date(serviceConfig.activateTo).getTime() < time.getTime()) return false;
+			if (serviceConfig.activateFrom && serviceConfig.activateFrom.getTime() > time.getTime()) return false;
+			if (serviceConfig.activateTo && serviceConfig.activateTo.getTime() < time.getTime()) return false;
 		}
 		if (userDeptConfig) {
-			if (userDeptConfig.activateFrom && new Date(userDeptConfig.activateFrom).getTime() > time.getTime()) return false;
-			if (userDeptConfig.activateTo && new Date(userDeptConfig.activateTo).getTime() < time.getTime()) return false;
+			if (userDeptConfig.activateFrom && userDeptConfig.activateFrom.getTime() > time.getTime()) return false;
+			if (userDeptConfig.activateTo && userDeptConfig.activateTo.getTime() < time.getTime()) return false;
 		}
 		return true;
 	}

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -11,6 +11,7 @@
 	import Modal from './Modal.svelte';
 	import { goto } from '$app/navigation';
 	import { config, user } from '$lib/store';
+	import { getDepartmentConfig, getServiceConfig } from '$lib/api/config';
 
 	let clazz = '';
 	export { clazz as class };
@@ -29,7 +30,7 @@
 		}
 	});
 
-	$: if ($config?.success && $user?.success && !disableBlock && !isReservable($config.result, $user.result, currentTime)) {
+	$: if ($config && $config.success && $user && $user.success && !disableBlock && !isReservable($config.result, $user.result, currentTime)) {
 		blockedModalOpen = true;
 	}
 
@@ -37,13 +38,14 @@
 
 	function isReservable(config: Config[], user: User, time: Date): boolean {
 		if (!user || user.isAdmin) return true;
-		const serviceConfig: ServiceConfig = (config ?? []).find((c: Config) => c.id === 'SERVICE') as ServiceConfig;
-		const userDeptConfig: DepartmentConfig = (config ?? []).find((c: Config) => c.id === user.department) as DepartmentConfig;
+		const serviceConfig: ServiceConfig = getServiceConfig(config) as ServiceConfig;
+		const userDeptConfig: DepartmentConfig = getDepartmentConfig(config, user.department) as DepartmentConfig;
 		if (serviceConfig) {
 			if (serviceConfig.activateFrom && serviceConfig.activateFrom.getTime() > time.getTime()) return false;
 			if (serviceConfig.activateTo && serviceConfig.activateTo.getTime() < time.getTime()) return false;
 		}
 		if (userDeptConfig) {
+			console.log(userDeptConfig);
 			if (userDeptConfig.activateFrom && userDeptConfig.activateFrom.getTime() > time.getTime()) return false;
 			if (userDeptConfig.activateTo && userDeptConfig.activateTo.getTime() < time.getTime()) return false;
 		}

--- a/packages/client/src/components/molecule/admin/department/DepartmentConfigSettings.svelte
+++ b/packages/client/src/components/molecule/admin/department/DepartmentConfigSettings.svelte
@@ -25,8 +25,8 @@
 	function initializeValues() {
 		id = original?.id ?? '';
 		name = original?.name ?? '';
-		activateFrom = original?.activateFrom ? new Date(original?.activateFrom) : null;
-		activateTo = original?.activateTo ? new Date(original?.activateTo) : null;
+		activateFrom = original?.activateFrom as Date ?? null;
+		activateTo = original?.activateTo as Date ?? null;
 		contact = original?.contact ?? '';
 	}
 
@@ -55,28 +55,28 @@
 	}
 </script>
 
-<div class='wrap'>
-	<div class='editor'>
+<div class='h-full flex flex-col justify-between p-3'>
+	<div class='flex flex-col mb-3'>
 		{#if isNew}
 			<h4>새 학부 추가</h4>
 		{:else}
 			<h4>{original.name} 수정</h4>
 		{/if}
-		<TextInput class='my-2' inputClass='reactive-input' id='id' label='학부 ID' showLabel disabled={!isNew}
+		<TextInput class='my-2' inputClass='w-full max-w-sm' id='id' label='학부 ID' showLabel disabled={!isNew}
 							 bind:value={id} required={isNew} pattern='\w+' invalidClass='text-red-800'
 							 invalidText={id ? 'ID는 알파벳 혹은 _ 만 허용됩니다.' : '이 값은 필수입니다.'} />
-		<TextInput class='my-2' inputClass='reactive-input' id='name' label='학부 이름' showLabel
+		<TextInput class='my-2' inputClass='w-full max-w-sm' id='name' label='학부 이름' showLabel
 							 bind:value={name} required invalidClass='text-red-800' invalidText='이 값은 필수입니다.' />
-		<DateTimeInput class='my-2' inputClass='reactive-input' id='activate_from' label='예약 시작일' showLabel
+		<DateTimeInput class='my-2' inputClass='w-full max-w-sm' id='activate_from' label='예약 시작일' showLabel
 									 bind:value={activateFrom} invalidClass='text-red-800' />
-		<DateTimeInput class='my-2' inputClass='reactive-input' id='activate_to' label='예약 종료일' showLabel
+		<DateTimeInput class='my-2' inputClass='w-full max-w-sm' id='activate_to' label='예약 종료일' showLabel
 									 bind:value={activateTo} invalidClass='text-red-800' />
-		<TextInput class='my-2' inputClass='reactive-input' id='contact' label='학부 연락처' showLabel
+		<TextInput class='my-2' inputClass='w-full max-w-sm' id='contact' label='학부 연락처' showLabel
 							 bind:value={contact} />
 	</div>
 	<div class='actions-wrap'>
 		<hr />
-		<div class='actions'>
+		<div class='flex justify-end gap-1 mt-3'>
 			{#if !isNew}
 				<Button on:click={deleteDepartment} class='bg-red-800 text-white' isIconRight>
 					삭제
@@ -99,21 +99,3 @@
 		</div>
 	</div>
 </div>
-
-<style>
-    .wrap {
-        @apply h-full flex flex-col justify-between p-3;
-    }
-
-    .editor :global(.reactive-input) {
-        @apply w-full max-w-sm;
-    }
-
-    .editor {
-        @apply flex flex-col mb-3;
-    }
-
-    .actions {
-        @apply flex justify-end gap-1 mt-3;
-    }
-</style>

--- a/packages/client/src/components/molecule/admin/department/DepartmentSettings.svelte
+++ b/packages/client/src/components/molecule/admin/department/DepartmentSettings.svelte
@@ -3,7 +3,7 @@
 	import UpdateScreen from '../../../atom/UpdateScreen.svelte';
 	import DepartmentConfigEditor from './DepartmentConfigEditor.svelte';
 	import Skeleton from "../../../atom/Skeleton.svelte";
-	import { deleteConfig, updateConfig } from '$lib/api/config';
+	import { apiDeleteConfig, apiUpdateConfig } from '$lib/api/config';
 
 	$: configs = $config.success ? $config.result.filter((v) => v.id !== 'SERVICE') : [];
 
@@ -12,7 +12,7 @@
 
 	function deleteDepartment(event: CustomEvent<ConfigDeleteRequest>) {
 		updating = true;
-		deleteConfig(event.detail)
+		apiDeleteConfig(event.detail)
 			.then(res => {
 				updating = false;
 				if (res.success) {
@@ -29,7 +29,7 @@
 
 	function updateDepartment(event: CustomEvent<ConfigUpdateRequest>) {
 		updating = true;
-		updateConfig(event.detail)
+		apiUpdateConfig(event.detail)
 			.then(res => {
 				updating = false;
 				if (res.success) {

--- a/packages/client/src/components/molecule/admin/department/DepartmentSettings.svelte
+++ b/packages/client/src/components/molecule/admin/department/DepartmentSettings.svelte
@@ -3,9 +3,9 @@
 	import UpdateScreen from '../../../atom/UpdateScreen.svelte';
 	import DepartmentConfigEditor from './DepartmentConfigEditor.svelte';
 	import Skeleton from "../../../atom/Skeleton.svelte";
-	import { apiDeleteConfig, apiUpdateConfig } from '$lib/api/config';
+	import { apiDeleteConfig, apiUpdateConfig, getDepartmentConfigs } from '$lib/api/config';
 
-	$: configs = $config.success ? $config.result.filter((v) => v.id !== 'SERVICE') : [];
+	$: configs = $config?.success ? getDepartmentConfigs($config.result) : [];
 
 	let updating = false;
 	$: if ($config) updating = false;
@@ -47,7 +47,7 @@
 
 <div class='my-8 md:mx-8 flex flex-col gap-3'>
 	<h3 class='mx-6 md:mx-0'>학부별 설정</h3>
-	{#if $config && !updating}
+	{#if $config?.success && !updating}
 		<div class='md:rounded-md shadow-md p-6 bg-white flex flex-col gap-3'>
 			<DepartmentConfigEditor on:delete={deleteDepartment} on:update={updateDepartment} {configs} />
 		</div>

--- a/packages/client/src/components/molecule/admin/department/DepartmentSettings.svelte
+++ b/packages/client/src/components/molecule/admin/department/DepartmentSettings.svelte
@@ -5,7 +5,7 @@
 	import Skeleton from "../../../atom/Skeleton.svelte";
 	import { apiDeleteConfig, apiUpdateConfig, getDepartmentConfigs } from '$lib/api/config';
 
-	$: configs = $config?.success ? getDepartmentConfigs($config.result) : [];
+	$: configs = $config && $config.success ? getDepartmentConfigs($config.result) : [];
 
 	let updating = false;
 	$: if ($config) updating = false;
@@ -47,7 +47,7 @@
 
 <div class='my-8 md:mx-8 flex flex-col gap-3'>
 	<h3 class='mx-6 md:mx-0'>학부별 설정</h3>
-	{#if $config?.success && !updating}
+	{#if $config && $config.success && !updating}
 		<div class='md:rounded-md shadow-md p-6 bg-white flex flex-col gap-3'>
 			<DepartmentConfigEditor on:delete={deleteDepartment} on:update={updateDepartment} {configs} />
 		</div>

--- a/packages/client/src/components/molecule/admin/service/ServiceSettings.svelte
+++ b/packages/client/src/components/molecule/admin/service/ServiceSettings.svelte
@@ -12,9 +12,9 @@
 	import Warning from '../../../../icons/Warning.svelte';
 	import Skeleton from "../../../atom/Skeleton.svelte";
 
-	$: serviceConfig = $config.success ? getServiceConfig($config.result) : undefined;
+	$: serviceConfig = $config?.success ? getServiceConfig($config.result) : undefined;
 
-	$: isServiceReady = !!($config.success && $config.result.find(v => v.id === 'SERVICE'));
+	$: isServiceReady = !!($config?.success && $config.result.find(v => v.id === 'SERVICE'));
 
 	let updating = false;
 

--- a/packages/client/src/components/molecule/admin/service/ServiceSettings.svelte
+++ b/packages/client/src/components/molecule/admin/service/ServiceSettings.svelte
@@ -6,7 +6,7 @@
 	import SaveEdit from '../../../../icons/SaveEdit.svelte';
 	import ArrowUndo from '../../../../icons/ArrowUndo.svelte';
 	import isEqual from 'lodash.isequal';
-	import { getServiceConfig, updateConfig as updateConfigToApi } from '$lib/api/config';
+	import { getServiceConfig, apiUpdateConfig } from '$lib/api/config';
 	import { config } from '$lib/store';
 	import UpdateScreen from '../../../atom/UpdateScreen.svelte';
 	import Warning from '../../../../icons/Warning.svelte';
@@ -53,7 +53,7 @@
 
 	function updateConfig() {
 		updating = true;
-		updateConfigToApi(newConfig)
+		apiUpdateConfig(newConfig)
 			.then(res => {
 				updating = false;
 				if (res.success) {

--- a/packages/client/src/components/molecule/admin/service/ServiceSettings.svelte
+++ b/packages/client/src/components/molecule/admin/service/ServiceSettings.svelte
@@ -12,9 +12,9 @@
 	import Warning from '../../../../icons/Warning.svelte';
 	import Skeleton from "../../../atom/Skeleton.svelte";
 
-	$: serviceConfig = $config?.success ? getServiceConfig($config.result) : undefined;
+	$: serviceConfig = $config && $config.success ? getServiceConfig($config.result) : undefined;
 
-	$: isServiceReady = !!($config?.success && $config.result.find(v => v.id === 'SERVICE'));
+	$: isServiceReady = !!($config && $config.success && $config.result.find(v => v.id === 'SERVICE'));
 
 	let updating = false;
 
@@ -124,7 +124,7 @@
 				{/if}
 			</div>
 		</section>
-		<section class='card'>
+		<section class='md:rounded-md shadow-md p-6 bg-white flex flex-col gap-3'>
 			<h4>건물/사물함 수정</h4>
 			{#if serviceConfig && isBuildingModified}
 				<div class='bg-primary-200 rounded-md p-6 flex gap-3'>

--- a/packages/client/src/components/molecule/admin/service/SubsectionEntry.svelte
+++ b/packages/client/src/components/molecule/admin/service/SubsectionEntry.svelte
@@ -5,6 +5,7 @@
 	import Select from '../../../atom/form/Select.svelte';
 	import { createEventDispatcher } from 'svelte';
 	import isEqual from 'lodash.isequal';
+	import { getDepartmentConfigs } from '$lib/api/config';
 
 	export let key: string;
 	export let subsection: LockerSubsection;
@@ -14,7 +15,7 @@
 		change: LockerSubsection
 	}>();
 
-	$: departments = $config ? $config.filter((v) => v.id !== 'SERVICE') : [];
+	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
 
 	let rangeStart = subsection?.range?.[0] ?? 0;
 	let rangeEnd = subsection?.range?.[1] ?? 0;
@@ -56,23 +57,23 @@
 	}
 </script>
 
-<div class='wrap'>
-	<div class='entry'>
-		<div class='remove'>
-			<button on:click={removeSubsection} class='remove-btn'>
+<div class='transition-all bg-white rounded-md flex flex-col gap-1 hover:brightness-95'>
+	<div class='transition-all flex items-center gap-3 overflow-hidden p-1'>
+		<div class='flex items-center'>
+			<button on:click={removeSubsection} class='transition-all rounded-md bg-gray-200 text-gray-500 hover:brightness-90'>
 				<Subtract />
 			</button>
 		</div>
-		<div class='inputs-wrap'>
-			<div class='range'>
+		<div class='flex flex-wrap items-center gap-3'>
+			<div class='rounded-md overflow-hidden flex items-center flex-wrap'>
 				<label>세부 구역 범위</label>
-				<div class='range-input'>
+				<div class='flex items-center'>
 					<NumberInput id='range-start' class='w-24' label='세부 구역 시작' bind:value={rangeStart} />
 					<div class='p-2'>~</div>
 					<NumberInput id='range-end' class='w-24' label='세부 구역 끝' bind:value={rangeEnd} />
 				</div>
 			</div>
-			<div class='department'>
+			<div class='flex items-center flex-wrap'>
 				<label>대상 학부</label>
 				<Select id={`subsection_${key}_department`} label='대상 학부' bind:value={department} required>
 					{#each departments as department}
@@ -89,47 +90,7 @@
 
 
 <style>
-    .wrap {
-        @apply transition-all bg-white rounded-md flex flex-col gap-1;
-    }
-
-    .wrap:hover {
-        @apply brightness-95;
-    }
-
-    label {
+		label {
         @apply font-bold mr-2;
-    }
-
-    .entry {
-        @apply transition-all flex items-center gap-3 overflow-hidden p-1;
-    }
-
-    .inputs-wrap {
-        @apply flex flex-wrap items-center gap-3;
-    }
-
-    .range {
-        @apply rounded-md overflow-hidden flex items-center flex-wrap;
-    }
-
-    .department {
-        @apply flex items-center flex-wrap;
-    }
-
-    .range-input {
-        @apply flex items-center;
-    }
-
-    .remove {
-        @apply flex items-center;
-    }
-
-    .remove-btn {
-        @apply transition-all rounded-md bg-gray-200 text-gray-500;
-    }
-
-    .remove-btn:hover {
-        @apply brightness-90;
     }
 </style>

--- a/packages/client/src/components/molecule/admin/service/SubsectionEntry.svelte
+++ b/packages/client/src/components/molecule/admin/service/SubsectionEntry.svelte
@@ -15,7 +15,7 @@
 		change: LockerSubsection
 	}>();
 
-	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
+	$: departments = $config && $config.success ? getDepartmentConfigs($config.result) : [];
 
 	let rangeStart = subsection?.range?.[0] ?? 0;
 	let rangeEnd = subsection?.range?.[1] ?? 0;

--- a/packages/client/src/components/molecule/admin/service/SubsectionSettings.svelte
+++ b/packages/client/src/components/molecule/admin/service/SubsectionSettings.svelte
@@ -6,7 +6,7 @@
 	import { getDepartmentConfigs } from '$lib/api/config';
 
 
-	$: departmentIds = $config?.success ? getDepartmentConfigs($config.result).map(v => v.id) : [];
+	$: departmentIds = $config && $config.success ? getDepartmentConfigs($config.result).map(v => v.id) : [];
 
 	export let subsections: LockerSubsection[];
 

--- a/packages/client/src/components/molecule/admin/service/SubsectionSettings.svelte
+++ b/packages/client/src/components/molecule/admin/service/SubsectionSettings.svelte
@@ -3,9 +3,10 @@
 	import Button from '../../../atom/Button.svelte';
 	import Add from '../../../../icons/Add.svelte';
 	import { config } from '$lib/store';
+	import { getDepartmentConfigs } from '$lib/api/config';
 
 
-	$: departmentIds = $config ? $config.filter(v => v.id !== 'SERVICE').map(v => v.id) : [];
+	$: departmentIds = $config?.success ? getDepartmentConfigs($config.result).map(v => v.id) : [];
 
 	export let subsections: LockerSubsection[];
 
@@ -37,7 +38,7 @@
 	}
 </script>
 
-<div class='wrap'>
+<div class='flex flex-col items-start'>
 	<p class='text-xl font-bold'>세부 구역 설정</p>
 	{#each newSubsections as subsection, index}
 		<div class='my-1'>
@@ -50,9 +51,3 @@
 		<Add slot='icon' />
 	</Button>
 </div>
-
-<style>
-    .wrap {
-        @apply flex flex-col items-start;
-    }
-</style>

--- a/packages/client/src/components/molecule/admin/user/UserDatatable.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserDatatable.svelte
@@ -130,7 +130,7 @@
 													on:change={(evt) => { selectionChange(user.id, evt.target.checked) }} />
 							</div>
 						</td>
-						<td>{getDepartmentNameById($config?.result ?? [], user.department) ?? '알 수 없음'}</td>
+						<td>{$config && $config.success ? getDepartmentNameById($config.result, user.department) : '알 수 없음'}</td>
 						<td>{user.id}</td>
 						<td>{user.name}</td>
 						<td>

--- a/packages/client/src/components/molecule/admin/user/UserDatatable.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserDatatable.svelte
@@ -1,3 +1,4 @@
+<!--suppress HtmlUnknownTag -->
 <script lang='ts'>
 	import { getDepartmentNameById } from '$lib/utils';
 	import { config } from '$lib/store';
@@ -77,26 +78,26 @@
 		return users.slice(start, start + itemsPerPage);
 	}
 </script>
-<div class='wrap'>
+<div class='flex flex-col h-full'>
 	{#if selected.length}
 		<div in:fly={{ y: 10, duration: 100 }} out:fly={{ y: 10, duration: 100 }}
 				 on:outrostart={() => batchActionOut = false}
-				 on:outroend={() => batchActionOut = true} class='batch'>
+				 on:outroend={() => batchActionOut = true} class='rounded-t-md bg-primary-800 text-white leading-6 py-2 px-3 border border-transparent flex justify-between'>
 			<div class='selections-text'>{selected.length}개 선택됨</div>
-			<div class='batch-actions'>
-				<button on:click={() => dispatch('batchUnclaim', {})} class='batch-btn'>
+			<div class='flex -m-2'>
+				<button on:click={() => dispatch('batchUnclaim', {})} class='rounded-xl bg-primary-800 flex gap-1 p-2 hover:brightness-90 active:brightness-75'>
 					<BookmarkOff />
 					예약 일괄 취소
 				</button>
-				<button on:click={() => dispatch('batchDelete', {})} class='batch-btn'>
+				<button on:click={() => dispatch('batchDelete', {})} class='rounded-xl bg-primary-800 flex gap-1 p-2 hover:brightness-90 active:brightness-75'>
 					<Delete />
 					삭제
 				</button>
 			</div>
 		</div>
 	{:else if batchActionOut}
-		<div class='actions'>
-			<div class='search'>
+		<div class='rounded-t-md bg-gray-100 flex w-full'>
+			<div class='flex w-full'>
 				<div class='flex justify-center items-center px-2 text-gray-500'>
 					<Search class='w-6 h-6' />
 				</div>
@@ -104,11 +105,11 @@
 			</div>
 		</div>
 	{/if}
-	<div class='table-wrap'>
+	<div class='grow'>
 		<table>
 			<thead>
 			<th class='w-6'>
-				<div class='checkbox-cell'>
+				<div class='flex justify-center items-center'>
 					<Checkbox id='select_all' bind:checked={selectAll} />
 				</div>
 			</th>
@@ -124,16 +125,16 @@
 				{#each shownUsers as user}
 					<tr>
 						<td>
-							<div class='checkbox-cell'>
+							<div class='flex justify-center items-center'>
 								<Checkbox id={`${user.id}`} checked={selected.includes(user.id)}
 													on:change={(evt) => { selectionChange(user.id, evt.target.checked) }} />
 							</div>
 						</td>
-						<td>{getDepartmentNameById($config, user.department) ?? '알 수 없음'}</td>
+						<td>{getDepartmentNameById($config?.result ?? [], user.department) ?? '알 수 없음'}</td>
 						<td>{user.id}</td>
 						<td>{user.name}</td>
 						<td>
-							<div class='checkbox-cell'>
+							<div class='flex justify-center items-center'>
 								<Checkbox id={`${user.id}_isAdmin`} checked={user.isAdmin} disabled />
 							</div>
 						</td>
@@ -158,48 +159,12 @@
 
 
 <style>
-    .wrap {
-        @apply flex flex-col h-full;
-    }
-
-    .table-wrap {
-        @apply grow;
-    }
-
-    table {
+		table {
         @apply table-auto min-w-[560px] w-full;
     }
 
     thead {
         @apply relative bg-gray-100;
-    }
-
-    .batch {
-        @apply rounded-t-md bg-primary-800 text-white leading-6 py-2 px-3 border border-transparent flex justify-between;
-    }
-
-    .batch-actions {
-        @apply flex -m-2;
-    }
-
-    .batch-btn {
-        @apply rounded-xl bg-primary-800 flex gap-1 p-2;
-    }
-
-    .batch-btn:hover {
-        @apply brightness-90;
-    }
-
-    .batch-btn:active {
-        @apply brightness-75;
-    }
-
-    .actions {
-        @apply rounded-t-md bg-gray-100 flex w-full;
-    }
-
-    .search {
-        @apply flex w-full;
     }
 
     th, td {
@@ -216,9 +181,5 @@
 
     tr:hover {
         @apply brightness-90;
-    }
-
-    .checkbox-cell {
-        @apply flex justify-center items-center;
     }
 </style>

--- a/packages/client/src/components/molecule/admin/user/UserEditModal.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserEditModal.svelte
@@ -22,7 +22,7 @@
 	let lockerId = targetUser?.lockerId ?? null;
 	let claimedUntil = targetUser?.claimedUntil ?? null;
 
-	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
+	$: departments = $config && $config.success ? getDepartmentConfigs($config.result) : [];
 
 	$: initializeValues(targetUser);
 

--- a/packages/client/src/components/molecule/admin/user/UserEditModal.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserEditModal.svelte
@@ -8,6 +8,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import Select from '../../../atom/form/Select.svelte';
 	import { config } from '$lib/store';
+	import { getDepartmentConfigs } from '$lib/api/config';
 
 	const dispatch = createEventDispatcher<{ submit: User }>();
 
@@ -19,9 +20,9 @@
 	let department = targetUser?.department ?? null;
 	let isAdmin = targetUser?.isAdmin ?? false;
 	let lockerId = targetUser?.lockerId ?? null;
-	let claimedUntil = targetUser?.claimedUntil ? new Date(targetUser?.claimedUntil) : null;
+	let claimedUntil = targetUser?.claimedUntil ?? null;
 
-	$: departments = $config ? $config.filter((v) => v.id !== 'SERVICE') : [];
+	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
 
 	$: initializeValues(targetUser);
 
@@ -33,7 +34,7 @@
 		department = targetUser?.department ?? null;
 		isAdmin = targetUser?.isAdmin ?? false;
 		lockerId = targetUser?.lockerId ?? null;
-		claimedUntil = targetUser?.claimedUntil ? new Date(targetUser?.claimedUntil) : null;
+		claimedUntil = targetUser?.claimedUntil ?? null;
 	}
 
 	function closeModal() {
@@ -55,7 +56,7 @@
 
 <Modal on:close on:click:secondary={closeModal} on:click={submitUser} {title} bind:open primaryText='저장'
 			 isPrimaryBtnIconRight isSecondaryBtnIconRight {...$$restProps}>
-	<div class='wrap'>
+	<div class='flex flex-col gap-1'>
 		<TextInput id='id' bind:value={id} label='학번' showLabel disabled={!!targetUser ? true : undefined}
 							 required={!targetUser} invalidClass='text-red-800'
 							 invalidText={id ? '학번은 숫자로만 이루어져야 합니다.' : '이 값은 필수입니다.'} pattern='\d+' />
@@ -77,9 +78,3 @@
 	<SaveEdit slot='primaryIcon' />
 	<Dismiss slot='secondaryIcon' />
 </Modal>
-
-<style>
-    .wrap {
-        @apply flex flex-col gap-1;
-    }
-</style>

--- a/packages/client/src/components/molecule/admin/user/UserExportModal.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserExportModal.svelte
@@ -11,7 +11,7 @@
 
 	const dispatch = createEventDispatcher<{ submit: { department: string; reservedOnly: boolean; } }>();
 
-	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
+	$: departments = $config && $config.success ? getDepartmentConfigs($config.result) : [];
 
 	export let open = false;
 	export let users: User[];

--- a/packages/client/src/components/molecule/admin/user/UserExportModal.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserExportModal.svelte
@@ -7,10 +7,11 @@
 	import Checkbox from '../../../atom/form/Checkbox.svelte';
 	import DocumentArrowLeft from '../../../../icons/DocumentArrowLeft.svelte';
 	import { createEventDispatcher } from 'svelte';
+	import { getDepartmentConfigs } from '$lib/api/config';
 
 	const dispatch = createEventDispatcher<{ submit: { department: string; reservedOnly: boolean; } }>();
 
-	$: departments = $config ? $config.filter((v) => v.id !== 'SERVICE') : [];
+	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
 
 	export let open = false;
 	export let users: User[];
@@ -30,7 +31,7 @@
 
 <Modal on:close on:click:secondary={closeModal} on:click={exportUsers} {title} bind:open primaryText='내보내기'
 			 isPrimaryBtnIconRight isSecondaryBtnIconRight {...$$restProps}>
-	<div class='wrap'>
+	<div class='flex flex-col gap-3'>
 		<Select id='department' label='대상 학부' showLabel bind:value={department} required invalidText='이 값은 필수입니다.'
 						invalidClass='text-red-800'>
 			<option value='all'>전체</option>
@@ -43,9 +44,3 @@
 	<DocumentArrowLeft slot='primaryIcon' />
 	<Dismiss slot='secondaryIcon' />
 </Modal>
-
-<style>
-    .wrap {
-        @apply flex flex-col gap-3;
-    }
-</style>

--- a/packages/client/src/components/molecule/admin/user/UserImportModal.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserImportModal.svelte
@@ -15,7 +15,7 @@
 
 	const dispatch = createEventDispatcher<{ submit: { overwrite: boolean, users: User[] } }>();
 
-	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
+	$: departments = $config && $config.success ? getDepartmentConfigs($config.result) : [];
 
 	export let open = false;
 

--- a/packages/client/src/components/molecule/admin/user/UserImportModal.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserImportModal.svelte
@@ -11,10 +11,11 @@
 	import { read, utils } from 'xlsx';
 	import Checkbox from '../../../atom/form/Checkbox.svelte';
 	import isEqual from 'lodash.isequal';
+	import { getDepartmentConfigs } from '$lib/api/config';
 
 	const dispatch = createEventDispatcher<{ submit: { overwrite: boolean, users: User[] } }>();
 
-	$: departments = $config ? $config.filter((v) => v.id !== 'SERVICE') : [];
+	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
 
 	export let open = false;
 
@@ -82,7 +83,7 @@
 <Modal on:close on:click:secondary={closeModal} on:click={submitUsers} {title} bind:open primaryText='업로드'
 			 primaryDisabled={!users}
 			 isPrimaryBtnIconRight isSecondaryBtnIconRight {...$$restProps}>
-	<div class='wrap'>
+	<div class='flex flex-col gap-3'>
 		<Select id='department' label='업로드 대상 학부' showLabel bind:value={department} required invalidText='이 값은 필수입니다.'
 						invalidClass='text-red-800'>
 			{#each departments as department}
@@ -111,9 +112,3 @@
 	<PeopleTeamAdd slot='primaryIcon' />
 	<Dismiss slot='secondaryIcon' />
 </Modal>
-
-<style>
-    .wrap {
-        @apply flex flex-col gap-3;
-    }
-</style>

--- a/packages/client/src/components/molecule/admin/user/UserSettings.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserSettings.svelte
@@ -84,7 +84,7 @@
 		uploadUserModalOpen = false;
 		const data = evt.detail;
 		const userKeys = users.map((u: User) => u.id);
-		const putUsers = data.overwrite ? data.users.filter((u: User) => !userKeys.includes(u.id)) : data.users;
+		const putUsers = data.overwrite ? data.users : data.users.filter((u: User) => !userKeys.includes(u.id));
 		dispatch('user:batchPut', putUsers);
 	}
 

--- a/packages/client/src/components/molecule/admin/user/UserSettings.svelte
+++ b/packages/client/src/components/molecule/admin/user/UserSettings.svelte
@@ -28,7 +28,7 @@
 
 	export let users: Array<User>;
 
-	$: departments = $config?.success ? getDepartmentConfigs($config.result) : [];
+	$: departments = $config && $config.success ? getDepartmentConfigs($config.result) : [];
 
 	let selectedTab;
 

--- a/packages/client/src/lib/api/api.ts
+++ b/packages/client/src/lib/api/api.ts
@@ -1,0 +1,47 @@
+import { fetchWithAuth } from '../auth';
+import { variables } from '../variables';
+
+export async function apiRequest<T>(
+	endpoint: string,
+	withAuth = false,
+	postBody?: unknown
+): Promise<SuccessResponse<T> | ErrorResponse<LockerError>> {
+	let response;
+	try {
+		if (withAuth) {
+			response = await fetchWithAuth(variables.baseUrl + '/api/v1' + endpoint, {
+				method: postBody ? 'POST' : 'GET',
+				...(postBody && { body: JSON.stringify(postBody) })
+			}).then((res) => res.json());
+		} else {
+			response = await fetch(variables.baseUrl + endpoint, {
+				method: postBody ? 'POST' : 'GET',
+				...(postBody && { body: JSON.stringify(postBody) })
+			}).then((res) => res.json());
+		}
+	} catch (e) {
+		console.error(e);
+		return {
+			success: false,
+			error: {
+				code: 500,
+				name: 'FetchError',
+				additionalInfo: e
+			}
+		};
+	}
+	if (Object.keys(response).includes('success')) {
+		if (response.success) {
+			return response as SuccessResponse<T>;
+		}
+		return response as ErrorResponse<LockerError>;
+	}
+	return {
+		success: false,
+		error: {
+			code: 500,
+			name: 'UnknownError',
+			additionalInfo: response
+		}
+	};
+}

--- a/packages/client/src/lib/api/api.ts
+++ b/packages/client/src/lib/api/api.ts
@@ -14,7 +14,7 @@ export async function apiRequest<T>(
 				...(postBody && { body: JSON.stringify(postBody) })
 			}).then((res) => res.json());
 		} else {
-			response = await fetch(variables.baseUrl + endpoint, {
+			response = await fetch(variables.baseUrl + '/api/v1' + endpoint, {
 				method: postBody ? 'POST' : 'GET',
 				...(postBody && { body: JSON.stringify(postBody) })
 			}).then((res) => res.json());

--- a/packages/client/src/lib/api/auth.ts
+++ b/packages/client/src/lib/api/auth.ts
@@ -16,7 +16,9 @@ const LoginSuccessResponseSchema = z.object({
 	expiresIn: z.number()
 });
 
-const LogoutSuccessResponseSchema = z.string();
+const LogoutSuccessResponseSchema = z.object({
+	accessToken: z.string()
+});
 
 type LoginSuccessResponse = z.infer<typeof LoginSuccessResponseSchema>;
 

--- a/packages/client/src/lib/api/auth.ts
+++ b/packages/client/src/lib/api/auth.ts
@@ -1,0 +1,64 @@
+/* eslint-disable import/extensions */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { z } from 'zod';
+import { apiRequest } from '$lib/api/api';
+import {
+	BlockedErrorSchema,
+	createErrorResponse,
+	createSuccessResponse,
+	UnauthorizedErrorSchema
+} from '$lib/api/schema';
+
+const LoginSuccessResponseSchema = z.object({
+	id: z.string().regex(/\d+/),
+	accessToken: z.string(),
+	tokenType: z.enum(['Bearer']),
+	expiresIn: z.number()
+});
+
+const LogoutSuccessResponseSchema = z.string();
+
+type LoginSuccessResponse = z.infer<typeof LoginSuccessResponseSchema>;
+
+type LogoutSuccessResponse = z.infer<typeof LogoutSuccessResponseSchema>;
+
+export async function apiSsuLogin(
+	result: string
+): Promise<
+	SuccessResponse<LoginSuccessResponse> | ErrorResponse<UnauthorizedError | BlockedError>
+> {
+	const response = await apiRequest<LoginSuccessResponse>(
+		'/auth/ssu_login?result=' + encodeURIComponent(result),
+		false
+	);
+	const login = createSuccessResponse(LoginSuccessResponseSchema).safeParse(response);
+	if (login.success) {
+		return login.data as SuccessResponse<LoginSuccessResponse>;
+	}
+	const unauthorized = createErrorResponse(UnauthorizedErrorSchema).safeParse(response);
+	if (unauthorized.success) {
+		return unauthorized.data as ErrorResponse<UnauthorizedError>;
+	}
+	const blocked = createErrorResponse(BlockedErrorSchema).safeParse(response);
+	if (blocked.success) {
+		return blocked.data as ErrorResponse<BlockedError>;
+	}
+	const other = createErrorResponse(z.object({})).parse(response);
+	throw other.error;
+}
+
+export async function apiLogout(): Promise<
+	SuccessResponse<LogoutSuccessResponse> | ErrorResponse<UnauthorizedError>
+> {
+	const response = await apiRequest<LogoutSuccessResponse>('/auth/logout', true);
+	const logout = createSuccessResponse(LogoutSuccessResponseSchema).safeParse(response);
+	if (logout.success) {
+		return logout.data as SuccessResponse<LogoutSuccessResponse>;
+	}
+	const unauthorized = createErrorResponse(UnauthorizedErrorSchema).safeParse(response);
+	if (unauthorized.success) {
+		return unauthorized.data as ErrorResponse<UnauthorizedError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}

--- a/packages/client/src/lib/api/config.ts
+++ b/packages/client/src/lib/api/config.ts
@@ -1,0 +1,120 @@
+/* eslint-disable import/extensions */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { z } from 'zod';
+import { apiRequest } from '$lib/api/api';
+import {
+	BadRequestErrorSchema,
+	createErrorResponse,
+	createSuccessResponse,
+	ForbiddenErrorSchema,
+	NotFoundErrorSchema
+} from '$lib/api/schema';
+
+const LockerSubsectionSchema = z.object({
+	department: z.string(),
+	range: z.tuple([z.number(), z.number()])
+});
+
+const LockerSectionSchema = z.object({
+	subsections: z.array(LockerSubsectionSchema).default([]),
+	disabled: z.array(z.number()).default([]),
+	height: z.number()
+});
+
+const BuildingSchema = z.object({
+	id: z.string().regex(/\d{2}/),
+	name: z.string(),
+	lockers: z.record(z.record(LockerSectionSchema).default({})).default({})
+});
+
+const ConfigSchema = z.object({
+	id: z.string().min(1),
+	name: z.string(),
+	activateFrom: z.optional(z.preprocess((isoDateStr: string) => new Date(isoDateStr), z.date())),
+	activateTo: z.optional(z.preprocess((isoDateStr: string) => new Date(isoDateStr), z.date()))
+});
+
+const DepartmentConfigSchema = ConfigSchema.extend({
+	contact: z.string().optional()
+});
+
+const ServiceConfigSchema = ConfigSchema.extend({
+	buildings: BuildingSchema.default({})
+});
+
+const ConfigUpdateRequestSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().optional(),
+	activateFrom: z.string().optional(),
+	activateTo: z.string().optional(),
+	contact: z.string().optional(),
+	buildings: BuildingSchema.optional()
+});
+
+export async function getConfig(): Promise<
+	SuccessResponse<Config[]> | ErrorResponse<NotFoundError>
+> {
+	const response = await apiRequest<ConfigResponse[]>('/config');
+	const get = createSuccessResponse(z.array(ConfigSchema)).safeParse(response);
+	if (get.success) {
+		return get.data as SuccessResponse<Config[]>;
+	}
+	const notFound = createErrorResponse(NotFoundErrorSchema).safeParse(response);
+	if (notFound.success) {
+		return notFound.data as ErrorResponse<NotFoundError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export function getServiceConfig(configs: Config[]): ServiceConfig {
+	return (
+		(configs.find((c: Config) => c.id === 'SERVICE') as ServiceConfig) ?? {
+			id: 'SERVICE',
+			name: null,
+			buildings: {}
+		}
+	);
+}
+
+export function getDepartmentConfig(configs: Config[], departmentId: string): DepartmentConfig {
+	return configs.find((c: Config) => c.id === departmentId) as DepartmentConfig;
+}
+
+export async function updateConfig(
+	updateRequest: ConfigUpdateRequest
+): Promise<SuccessResponse<ConfigUpdateRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<ConfigUpdateRequest>('/config/update', true, updateRequest);
+	const update = createSuccessResponse(ConfigUpdateRequestSchema).safeParse(response);
+	if (update.success) {
+		return update.data as SuccessResponse<ConfigUpdateRequest>;
+	}
+	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
+	if (badRequest.success) {
+		return badRequest.data as ErrorResponse<BadRequestError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function deleteConfig(
+	ids: string[]
+): Promise<SuccessResponse<string[]> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<string[]>('/config/delete', true, ids);
+	const deleteValidation = createSuccessResponse(z.array(z.string())).safeParse(response);
+	if (deleteValidation.success) {
+		return deleteValidation.data as SuccessResponse<string[]>;
+	}
+	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
+	if (badRequest.success) {
+		return badRequest.data as ErrorResponse<BadRequestError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+}

--- a/packages/client/src/lib/api/config.ts
+++ b/packages/client/src/lib/api/config.ts
@@ -102,12 +102,12 @@ export async function updateConfig(
 }
 
 export async function deleteConfig(
-	ids: string[]
-): Promise<SuccessResponse<string[]> | ErrorResponse<BadRequestError | ForbiddenError>> {
-	const response = await apiRequest<string[]>('/config/delete', true, ids);
-	const deleteValidation = createSuccessResponse(z.array(z.string())).safeParse(response);
+	configDeleteRequest: ConfigDeleteRequest
+): Promise<SuccessResponse<ConfigDeleteRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<string>('/config/delete', true, configDeleteRequest);
+	const deleteValidation = createSuccessResponse(z.object({ id: z.string() })).safeParse(response);
 	if (deleteValidation.success) {
-		return deleteValidation.data as SuccessResponse<string[]>;
+		return deleteValidation.data as SuccessResponse<ConfigDeleteRequest>;
 	}
 	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
 	if (badRequest.success) {

--- a/packages/client/src/lib/api/config.ts
+++ b/packages/client/src/lib/api/config.ts
@@ -81,6 +81,10 @@ export function getDepartmentConfig(configs: Config[], departmentId: string): De
 	return configs.find((c: Config) => c.id === departmentId) as DepartmentConfig;
 }
 
+export function getDepartmentConfigs(configs: Config[]): DepartmentConfig[] {
+	return configs.filter((c: Config) => c.id !== 'SERVICE') as DepartmentConfig[];
+}
+
 export async function apiUpdateConfig(
 	updateRequest: ConfigUpdateRequest
 ): Promise<SuccessResponse<ConfigUpdateRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {

--- a/packages/client/src/lib/api/config.ts
+++ b/packages/client/src/lib/api/config.ts
@@ -51,7 +51,7 @@ const ConfigUpdateRequestSchema = z.object({
 	buildings: BuildingSchema.optional()
 });
 
-export async function getConfig(): Promise<
+export async function apiGetConfig(): Promise<
 	SuccessResponse<Config[]> | ErrorResponse<NotFoundError>
 > {
 	const response = await apiRequest<ConfigResponse[]>('/config');
@@ -81,7 +81,7 @@ export function getDepartmentConfig(configs: Config[], departmentId: string): De
 	return configs.find((c: Config) => c.id === departmentId) as DepartmentConfig;
 }
 
-export async function updateConfig(
+export async function apiUpdateConfig(
 	updateRequest: ConfigUpdateRequest
 ): Promise<SuccessResponse<ConfigUpdateRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
 	const response = await apiRequest<ConfigUpdateRequest>('/config/update', true, updateRequest);
@@ -101,7 +101,7 @@ export async function updateConfig(
 	throw other.error;
 }
 
-export async function deleteConfig(
+export async function apiDeleteConfig(
 	configDeleteRequest: ConfigDeleteRequest
 ): Promise<SuccessResponse<ConfigDeleteRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
 	const response = await apiRequest<string>('/config/delete', true, configDeleteRequest);

--- a/packages/client/src/lib/api/locker.ts
+++ b/packages/client/src/lib/api/locker.ts
@@ -1,0 +1,132 @@
+/* eslint-disable import/extensions */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { z } from 'zod';
+import { apiRequest } from '$lib/api/api';
+import {
+	BadRequestErrorSchema,
+	BlockedErrorSchema,
+	CantClaimErrorSchema,
+	createErrorResponse,
+	createSuccessResponse,
+	ForbiddenErrorSchema,
+	InternalErrorSchema,
+	NotFoundErrorSchema
+} from '$lib/api/schema';
+
+const ReservedLockerSchema = z.object({
+	id: z.string().regex(/\d+/).optional(),
+	lockerId: z.string(),
+	claimedUntil: z.preprocess((isoString: string) => new Date(isoString), z.date()).optional()
+});
+
+const ClaimLockerResponseSchema = ReservedLockerSchema;
+
+const UnclaimLockerResponseSchema = z.object({
+	id: z.string().regex(/\d+/).optional(),
+	lockerId: z.string()
+});
+
+const LockerCountResponseSchema = z.record(z.record(z.number()));
+
+export async function queryLocker(
+	showId = false
+): Promise<SuccessResponse<ReservedLocker[]> | ErrorResponse<ForbiddenError | NotFoundError>> {
+	const response = await apiRequest<ReservedLockerResponse[]>(
+		`/locker/query${showId ? '?show_id=true' : ''}`,
+		true
+	);
+	const query = createSuccessResponse(z.array(ReservedLockerSchema)).safeParse(response);
+	if (query.success) {
+		return query.data as SuccessResponse<ReservedLocker[]>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const notFound = createErrorResponse(NotFoundErrorSchema).safeParse(response);
+	if (notFound.success) {
+		return notFound.data as ErrorResponse<NotFoundError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function countLocker(): Promise<
+	SuccessResponse<LockerCountResponse> | ErrorResponse<NotFoundError>
+> {
+	const response = await apiRequest<LockerCountResponse>('/locker/count');
+	const count = createSuccessResponse(LockerCountResponseSchema).safeParse(response);
+	if (count.success) {
+		return count.data as SuccessResponse<LockerCountResponse>;
+	}
+	const notFound = createErrorResponse(NotFoundErrorSchema).safeParse(response);
+	if (notFound.success) {
+		return notFound.data as ErrorResponse<NotFoundError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function claimLocker(
+	lockerId: string,
+	claimedUntil?: Date
+): Promise<
+	| SuccessResponse<ReservedLocker>
+	| ErrorResponse<BadRequestError | BlockedError | ForbiddenError | CantClaimError | InternalError>
+> {
+	const response = await apiRequest<ClaimLockerResponse>('/locker/claim', true, {
+		lockerId,
+		...(claimedUntil && { until: claimedUntil.toISOString() })
+	});
+	const claim = createSuccessResponse(ClaimLockerResponseSchema).safeParse(response);
+	if (claim.success) {
+		return claim.data as SuccessResponse<ReservedLocker>;
+	}
+	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
+	if (badRequest.success) {
+		return badRequest.data as ErrorResponse<BadRequestError>;
+	}
+	const blocked = createErrorResponse(BlockedErrorSchema).safeParse(response);
+	if (blocked.success) {
+		return blocked.data as ErrorResponse<BlockedError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const cantClaim = createErrorResponse(CantClaimErrorSchema).safeParse(response);
+	if (cantClaim.success) {
+		return cantClaim.data as ErrorResponse<CantClaimError>;
+	}
+	const internal = createErrorResponse(InternalErrorSchema).safeParse(response);
+	if (internal.success) {
+		return internal.data as ErrorResponse<InternalError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function unclaimLocker(): Promise<
+	| SuccessResponse<UnclaimLockerResponse>
+	| ErrorResponse<BlockedError | ForbiddenError | CantClaimError>
+> {
+	const response = await apiRequest<UnclaimLockerResponse>('/locker/unclaim', true);
+	const unclaim = createSuccessResponse(UnclaimLockerResponseSchema).safeParse(response);
+	if (unclaim.success) {
+		return unclaim.data as SuccessResponse<UnclaimLockerResponse>;
+	}
+	const blocked = createErrorResponse(BlockedErrorSchema).safeParse(response);
+	if (blocked.success) {
+		return blocked.data as ErrorResponse<BlockedError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const cantClaim = createErrorResponse(CantClaimErrorSchema).safeParse(response);
+	if (cantClaim.success) {
+		return cantClaim.data as ErrorResponse<CantClaimError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}

--- a/packages/client/src/lib/api/locker.ts
+++ b/packages/client/src/lib/api/locker.ts
@@ -28,7 +28,7 @@ const UnclaimLockerResponseSchema = z.object({
 
 const LockerCountResponseSchema = z.record(z.record(z.number()));
 
-export async function queryLocker(
+export async function apiQueryLocker(
 	showId = false
 ): Promise<SuccessResponse<ReservedLocker[]> | ErrorResponse<ForbiddenError | NotFoundError>> {
 	const response = await apiRequest<ReservedLockerResponse[]>(
@@ -51,7 +51,7 @@ export async function queryLocker(
 	throw other.error;
 }
 
-export async function countLocker(): Promise<
+export async function apiCountLocker(): Promise<
 	SuccessResponse<LockerCountResponse> | ErrorResponse<NotFoundError>
 > {
 	const response = await apiRequest<LockerCountResponse>('/locker/count');
@@ -67,7 +67,7 @@ export async function countLocker(): Promise<
 	throw other.error;
 }
 
-export async function claimLocker(
+export async function apiClaimLocker(
 	lockerId: string,
 	claimedUntil?: Date
 ): Promise<
@@ -106,7 +106,7 @@ export async function claimLocker(
 	throw other.error;
 }
 
-export async function unclaimLocker(): Promise<
+export async function apiUnclaimLocker(): Promise<
 	| SuccessResponse<UnclaimLockerResponse>
 	| ErrorResponse<BlockedError | ForbiddenError | CantClaimError>
 > {

--- a/packages/client/src/lib/api/schema.ts
+++ b/packages/client/src/lib/api/schema.ts
@@ -1,0 +1,71 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { z } from 'zod';
+
+export function createSuccessResponse(schema: z.ZodTypeAny = z.any().optional()) {
+	return z
+		.object({
+			success: z.literal(true)
+		})
+		.extend({
+			result: schema
+		})
+		.passthrough();
+}
+
+export function createErrorResponse(schema: z.ZodTypeAny = z.any().optional()) {
+	return z
+		.object({
+			success: z.literal(false)
+		})
+		.extend({
+			error: schema
+		})
+		.passthrough();
+}
+
+export const BadRequestErrorSchema = z
+	.object({
+		code: z.literal(400),
+		name: z.literal('BadRequest')
+	})
+	.passthrough();
+
+export const UnauthorizedErrorSchema = z
+	.object({
+		code: z.literal(401),
+		name: z.literal('Unauthorized')
+	})
+	.passthrough();
+
+export const ForbiddenErrorSchema = z
+	.object({
+		code: z.literal(403),
+		name: z.literal('Forbidden')
+	})
+	.passthrough();
+
+export const BlockedErrorSchema = z
+	.object({
+		code: z.literal(403),
+		name: z.literal('Blocked')
+	})
+	.passthrough();
+
+export const NotFoundErrorSchema = z
+	.object({
+		code: z.literal(404),
+		name: z.literal('NotFound')
+	})
+	.passthrough();
+
+export const CantClaimErrorSchema = z
+	.object({
+		code: z.literal(403),
+		name: z.literal('CantClaim')
+	})
+	.passthrough();
+
+export const InternalErrorSchema = z.object({
+	code: z.literal(500),
+	name: z.literal('InternalError')
+});

--- a/packages/client/src/lib/api/user.ts
+++ b/packages/client/src/lib/api/user.ts
@@ -128,9 +128,19 @@ export async function queryUser(
 }
 
 export async function batchPutUser(
-	users: BatchUserPutRequest
+	users: User[]
 ): Promise<SuccessResponse<BatchUserPutRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
-	const response = await apiRequest<BatchUserPutRequest>('/user/batch/put', true, users);
+	function toUserResponse(user: User) {
+		return {
+			...user,
+			...(user.claimedUntil && { claimedUntil: user.claimedUntil.toISOString() })
+		};
+	}
+	const response = await apiRequest<BatchUserPutRequest>(
+		'/user/batch/put',
+		true,
+		users.map(toUserResponse)
+	);
 	const batchPut = createSuccessResponse(BatchUserPutRequestSchema).safeParse(response);
 	if (batchPut.success) {
 		return batchPut.data as SuccessResponse<BatchUserPutRequest>;

--- a/packages/client/src/lib/api/user.ts
+++ b/packages/client/src/lib/api/user.ts
@@ -12,14 +12,16 @@ import {
 
 const UserSchema = z.object({
 	id: z.string().regex(/\d+/),
-	name: z.string().default(''),
+	name: z.string().nullable().default(null),
 	isAdmin: z.boolean().default(false),
-	department: z.string().default(null),
+	department: z.string().nullable().default(null),
 	lockerId: z.string().optional(),
-	claimedUntil: z.preprocess(
-		(num: number) => (typeof num === 'number' && num >= 0 ? new Date(num) : null),
-		z.date().nullable().optional()
-	)
+	claimedUntil: z
+		.preprocess(
+			(num: number) => (typeof num === 'number' && num >= 0 ? new Date(num) : null),
+			z.date().nullable().optional()
+		)
+		.optional()
 });
 
 const UserUpdateRequestSchema = z.object({
@@ -69,11 +71,11 @@ export async function apiGetUser(
 
 export async function apiUpdateUser(
 	userUpdateRequest: UserUpdateRequest
-): Promise<SuccessResponse<UserUpdateRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
-	const response = await apiRequest<UserUpdateRequest>('/user/update', true, userUpdateRequest);
-	const update = createSuccessResponse(UserUpdateRequestSchema).safeParse(response);
+): Promise<SuccessResponse<never> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<never>('/user/update', true, userUpdateRequest);
+	const update = createSuccessResponse().safeParse(response);
 	if (update.success) {
-		return update.data as SuccessResponse<UserUpdateRequest>;
+		return update.data as SuccessResponse<never>;
 	}
 	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
 	if (badRequest.success) {
@@ -109,7 +111,8 @@ export async function apiQueryUser(
 	starts?: string
 ): Promise<SuccessResponse<User[]> | ErrorResponse<ForbiddenError | NotFoundError>> {
 	const response = await apiRequest<UserResponse[]>(
-		`/user/query${starts ? '?starts=' + encodeURIComponent(starts) : ''}`
+		`/user/query${starts ? '?starts=' + encodeURIComponent(starts) : ''}`,
+		true
 	);
 	const query = createSuccessResponse(z.array(UserSchema)).safeParse(response);
 	if (query.success) {
@@ -129,21 +132,17 @@ export async function apiQueryUser(
 
 export async function apiBatchPutUser(
 	users: User[]
-): Promise<SuccessResponse<BatchUserPutRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
+): Promise<SuccessResponse<never> | ErrorResponse<BadRequestError | ForbiddenError>> {
 	function toUserResponse(user: User) {
 		return {
 			...user,
 			...(user.claimedUntil && { claimedUntil: user.claimedUntil.toISOString() })
 		};
 	}
-	const response = await apiRequest<BatchUserPutRequest>(
-		'/user/batch/put',
-		true,
-		users.map(toUserResponse)
-	);
-	const batchPut = createSuccessResponse(BatchUserPutRequestSchema).safeParse(response);
+	const response = await apiRequest<never>('/user/batch/put', true, users.map(toUserResponse));
+	const batchPut = createSuccessResponse().safeParse(response);
 	if (batchPut.success) {
-		return batchPut.data as SuccessResponse<BatchUserPutRequest>;
+		return batchPut.data as SuccessResponse<never>;
 	}
 	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
 	if (badRequest.success) {
@@ -159,11 +158,11 @@ export async function apiBatchPutUser(
 
 export async function apiBatchDeleteUser(
 	batchUserDeleteRequest: string[]
-): Promise<SuccessResponse<string[]> | ErrorResponse<BadRequestError | ForbiddenError>> {
-	const response = await apiRequest<string[]>('/user/batch/delete', true, batchUserDeleteRequest);
-	const batchDelete = createSuccessResponse(z.array(z.string())).safeParse(response);
+): Promise<SuccessResponse<never> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<never>('/user/batch/delete', true, batchUserDeleteRequest);
+	const batchDelete = createSuccessResponse().safeParse(response);
 	if (batchDelete.success) {
-		return batchDelete.data as SuccessResponse<string[]>;
+		return batchDelete.data as SuccessResponse<never>;
 	}
 	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
 	if (badRequest.success) {

--- a/packages/client/src/lib/api/user.ts
+++ b/packages/client/src/lib/api/user.ts
@@ -1,0 +1,168 @@
+/* eslint-disable import/extensions */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { z } from 'zod';
+import { apiRequest } from '$lib/api/api';
+import {
+	BadRequestErrorSchema,
+	createErrorResponse,
+	createSuccessResponse,
+	ForbiddenErrorSchema,
+	NotFoundErrorSchema
+} from '$lib/api/schema';
+
+const UserSchema = z.object({
+	id: z.string().regex(/\d+/),
+	name: z.string().default(''),
+	isAdmin: z.boolean().default(false),
+	department: z.string().default(null),
+	lockerId: z.string().optional(),
+	claimedUntil: z.preprocess(
+		(num: number) => (typeof num === 'number' && num >= 0 ? new Date(num) : null),
+		z.date().nullable().optional()
+	)
+});
+
+const UserUpdateRequestSchema = z.object({
+	id: z.string().regex(/\d+/),
+	name: z.string().optional(),
+	isAdmin: z.boolean().optional(),
+	department: z.string().optional(),
+	lockerId: z.string().optional(),
+	claimedUntil: z.string().optional()
+});
+
+const BatchUserPutRequestSchema = z.array(
+	z.object({
+		id: z.string().regex(/\d+/),
+		name: z.string(),
+		isAdmin: z.boolean(),
+		department: z.string(),
+		lockerId: z.string().optional(),
+		claimedUntil: z.string().optional()
+	})
+);
+
+const UserDeleteRequestSchema = z.object({ id: z.string() });
+
+export async function getUser(
+	id?: string
+): Promise<SuccessResponse<User> | ErrorResponse<ForbiddenError | NotFoundError>> {
+	const response = await apiRequest<UserResponse>(
+		`/user${id ? '?id=' + encodeURIComponent(id) : ''}`,
+		true
+	);
+	const get = createSuccessResponse(UserSchema).safeParse(response);
+	if (get.success) {
+		return get.data as SuccessResponse<User>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const notFound = createErrorResponse(NotFoundErrorSchema).safeParse(response);
+	if (notFound.success) {
+		return notFound.data as ErrorResponse<NotFoundError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function updateUser(
+	userUpdateRequest: UserUpdateRequest
+): Promise<SuccessResponse<UserUpdateRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<UserUpdateRequest>('/user/update', true, userUpdateRequest);
+	const update = createSuccessResponse(UserUpdateRequestSchema).safeParse(response);
+	if (update.success) {
+		return update.data as SuccessResponse<UserUpdateRequest>;
+	}
+	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
+	if (badRequest.success) {
+		return badRequest.data as ErrorResponse<BadRequestError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function deleteUser(
+	userDeleteRequest: UserDeleteRequest
+): Promise<SuccessResponse<UserDeleteRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<UserDeleteRequest>('/user/delete', true, userDeleteRequest);
+	const deleteValidation = createSuccessResponse(UserDeleteRequestSchema).safeParse(response);
+	if (deleteValidation.success) {
+		return deleteValidation.data as SuccessResponse<UserDeleteRequest>;
+	}
+	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
+	if (badRequest.success) {
+		return badRequest.data as ErrorResponse<BadRequestError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+}
+
+export async function queryUser(
+	starts?: string
+): Promise<SuccessResponse<User[]> | ErrorResponse<ForbiddenError | NotFoundError>> {
+	const response = await apiRequest<UserResponse[]>(
+		`/user/query${starts ? '?starts=' + encodeURIComponent(starts) : ''}`
+	);
+	const query = createSuccessResponse(z.array(UserSchema)).safeParse(response);
+	if (query.success) {
+		return query.data as SuccessResponse<User[]>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const notFound = createErrorResponse(NotFoundErrorSchema).safeParse(response);
+	if (notFound.success) {
+		return notFound.data as ErrorResponse<NotFoundError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function batchPutUser(
+	users: BatchUserPutRequest
+): Promise<SuccessResponse<BatchUserPutRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<BatchUserPutRequest>('/user/batch/put', true, users);
+	const batchPut = createSuccessResponse(BatchUserPutRequestSchema).safeParse(response);
+	if (batchPut.success) {
+		return batchPut.data as SuccessResponse<BatchUserPutRequest>;
+	}
+	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
+	if (badRequest.success) {
+		return badRequest.data as ErrorResponse<BadRequestError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}
+
+export async function batchDeleteUser(
+	batchUserDeleteRequest: string[]
+): Promise<SuccessResponse<string[]> | ErrorResponse<BadRequestError | ForbiddenError>> {
+	const response = await apiRequest<string[]>('/user/batch/delete', true, batchUserDeleteRequest);
+	const batchDelete = createSuccessResponse(z.array(z.string())).safeParse(response);
+	if (batchDelete.success) {
+		return batchDelete.data as SuccessResponse<string[]>;
+	}
+	const badRequest = createErrorResponse(BadRequestErrorSchema).safeParse(response);
+	if (badRequest.success) {
+		return badRequest.data as ErrorResponse<BadRequestError>;
+	}
+	const forbidden = createErrorResponse(ForbiddenErrorSchema).safeParse(response);
+	if (forbidden.success) {
+		return forbidden.data as ErrorResponse<ForbiddenError>;
+	}
+	const other = createErrorResponse().parse(response);
+	throw other.error;
+}

--- a/packages/client/src/lib/api/user.ts
+++ b/packages/client/src/lib/api/user.ts
@@ -44,7 +44,7 @@ const BatchUserPutRequestSchema = z.array(
 
 const UserDeleteRequestSchema = z.object({ id: z.string() });
 
-export async function getUser(
+export async function apiGetUser(
 	id?: string
 ): Promise<SuccessResponse<User> | ErrorResponse<ForbiddenError | NotFoundError>> {
 	const response = await apiRequest<UserResponse>(
@@ -67,7 +67,7 @@ export async function getUser(
 	throw other.error;
 }
 
-export async function updateUser(
+export async function apiUpdateUser(
 	userUpdateRequest: UserUpdateRequest
 ): Promise<SuccessResponse<UserUpdateRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
 	const response = await apiRequest<UserUpdateRequest>('/user/update', true, userUpdateRequest);
@@ -87,7 +87,7 @@ export async function updateUser(
 	throw other.error;
 }
 
-export async function deleteUser(
+export async function apiDeleteUser(
 	userDeleteRequest: UserDeleteRequest
 ): Promise<SuccessResponse<UserDeleteRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
 	const response = await apiRequest<UserDeleteRequest>('/user/delete', true, userDeleteRequest);
@@ -105,7 +105,7 @@ export async function deleteUser(
 	}
 }
 
-export async function queryUser(
+export async function apiQueryUser(
 	starts?: string
 ): Promise<SuccessResponse<User[]> | ErrorResponse<ForbiddenError | NotFoundError>> {
 	const response = await apiRequest<UserResponse[]>(
@@ -127,7 +127,7 @@ export async function queryUser(
 	throw other.error;
 }
 
-export async function batchPutUser(
+export async function apiBatchPutUser(
 	users: User[]
 ): Promise<SuccessResponse<BatchUserPutRequest> | ErrorResponse<BadRequestError | ForbiddenError>> {
 	function toUserResponse(user: User) {
@@ -157,7 +157,7 @@ export async function batchPutUser(
 	throw other.error;
 }
 
-export async function batchDeleteUser(
+export async function apiBatchDeleteUser(
 	batchUserDeleteRequest: string[]
 ): Promise<SuccessResponse<string[]> | ErrorResponse<BadRequestError | ForbiddenError>> {
 	const response = await apiRequest<string[]>('/user/batch/delete', true, batchUserDeleteRequest);

--- a/packages/client/src/lib/store.ts
+++ b/packages/client/src/lib/store.ts
@@ -6,8 +6,8 @@ import { writable } from 'svelte/store';
 // @ts-ignore
 import { browser } from '$app/env';
 import { getAuthorization } from '$lib/auth';
-import { getConfig } from '$lib/api/config';
-import { getUser } from '$lib/api/user';
+import { apiGetConfig } from '$lib/api/config';
+import { apiGetUser } from '$lib/api/user';
 
 type ConfigStore = {
 	lastUpdated: string;
@@ -54,7 +54,7 @@ async function refreshConfig(
 			}
 		}
 		try {
-			return await getConfig().then((data) => {
+			return await apiGetConfig().then((data) => {
 				if (data.success) {
 					const result: Config[] = data.result;
 					localStorage.setItem(
@@ -88,7 +88,7 @@ async function refreshConfig(
 async function refreshUser(): Promise<SuccessResponse<User> | ErrorResponse<LockerError>> {
 	if (getAuthorization()) {
 		try {
-			return await getUser().then((res) => {
+			return await apiGetUser().then((res) => {
 				if (res.success) {
 					return res;
 				} else {

--- a/packages/client/src/lib/store.ts
+++ b/packages/client/src/lib/store.ts
@@ -123,7 +123,9 @@ export const config: Refreshable<
 	undefined,
 	(set) => {
 		set(undefined);
-		refreshConfig().then((value) => set(value));
+		refreshConfig()
+			.then((value) => set(value))
+			.catch((e) => console.error(e));
 		return function stop() {
 			set(undefined);
 		};
@@ -137,7 +139,9 @@ export const user: Refreshable<SuccessResponse<User> | undefined | ErrorResponse
 		(set) => {
 			if (browser) {
 				set(undefined);
-				refreshUser().then((value) => set(value));
+				refreshUser()
+					.then((value) => set(value))
+					.catch((e) => console.error(e));
 			}
 			return function stop() {
 				set(undefined);

--- a/packages/client/src/lib/store.ts
+++ b/packages/client/src/lib/store.ts
@@ -125,7 +125,10 @@ export const config: Refreshable<
 		set(undefined);
 		refreshConfig()
 			.then((value) => set(value))
-			.catch((e) => console.error(e));
+			.catch((e) => {
+				console.error(e);
+				set(null);
+			});
 		return function stop() {
 			set(undefined);
 		};
@@ -141,7 +144,10 @@ export const user: Refreshable<SuccessResponse<User> | undefined | ErrorResponse
 				set(undefined);
 				refreshUser()
 					.then((value) => set(value))
-					.catch((e) => console.error(e));
+					.catch((e) => {
+						console.error(e);
+						set(null);
+					});
 			}
 			return function stop() {
 				set(undefined);

--- a/packages/client/src/lib/types.ts
+++ b/packages/client/src/lib/types.ts
@@ -1,3 +1,16 @@
+/* API Call types */
+
+export type FetchError = LockerError & {
+	code: 500;
+	name: 'FetchError';
+};
+export type UnknownError = LockerError & {
+	code: 500;
+	name: 'UnknownError';
+};
+
+/* LockerCount Types */
+
 export type LockerCount = {
 	[department: string]: DepartmentLockerCount;
 };

--- a/packages/client/src/routes/+page.svelte
+++ b/packages/client/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 	import PageTitle from '../components/atom/PageTitle.svelte';
 	import Modal from '../components/molecule/Modal.svelte';
 	import Dismiss from '../icons/Dismiss.svelte';
-	import { countLocker } from '$lib/api/locker';
+	import { apiCountLocker } from '$lib/api/locker';
 
 	let callbackUrl = undefined;
 
@@ -36,7 +36,7 @@
 		}
 		callbackUrl = window.location.protocol + '//' + window.location.host + '/callback';
 		callbackNotLoaded = false;
-		countLocker()
+		apiCountLocker()
 			.then((data) => {
 				if (data.success) {
 					countData = data.result;

--- a/packages/client/src/routes/+page.svelte
+++ b/packages/client/src/routes/+page.svelte
@@ -128,8 +128,8 @@
 <Modal title='학과(부) 연락처' bind:open={contactModalOpen} secondaryClass='hidden' primaryText='닫기'
 			 on:close={() => contactModalOpen = false}
 			 on:click={() => contactModalOpen = false}>
-	{#each ($config ?? []) as config}
-		{#if config?.contact}
+	{#each ($config?.result ?? []) as config}
+		{#if config.contact}
 			<div class='my-2 leading-10'>
 				<h5>{config.name} 연락처</h5>
 				<p class='text-gray-700'>{config.contact}</p>

--- a/packages/client/src/routes/admin/+page.svelte
+++ b/packages/client/src/routes/admin/+page.svelte
@@ -12,8 +12,8 @@
 	import Settings from '../../icons/Settings.svelte';
 	import ContentSettings from '../../icons/ContentSettings.svelte';
 	import { browser } from '$app/env';
-	import { deleteAuthorization, fetchWithAuth } from '$lib/auth';
-	import { variables } from '$lib/variables';
+	import { deleteAuthorization } from '$lib/auth';
+	import { queryUser as queryUserFromApi, updateUser as updateUserFromApi, batchPutUser as batchPutUserFromApi, batchDeleteUser as batchDeleteUserFromApi } from '$lib/api/user';
 	import LoadingScreen from '../../components/atom/LoadingScreen.svelte';
 	import ErrorScreen from '../../components/atom/ErrorScreen.svelte';
 	import Skeleton from '../../components/atom/Skeleton.svelte';
@@ -46,12 +46,12 @@
 	}
 
 	function queryUser() {
-		userPromise = fetchWithAuth(variables.baseUrl + '/api/v1/user/query').then((res) => res.json())
+		userPromise = queryUserFromApi()
 			.then((res) => {
 				if (res.success) {
 					return res.result;
 				}
-				throw new Error(res.errorDescription);
+				throw (res as ErrorResponse<LockerError>).error;
 			})
 			.catch((err) => {
 				console.error(err);
@@ -60,16 +60,14 @@
 
 	function updateUser(evt: CustomEvent<UserUpdateRequest>) {
 		userUpdating = true;
-		fetchWithAuth(variables.baseUrl + '/api/v1/user/update', {
-			method: 'POST',
-			body: JSON.stringify(evt.detail)
-		}).then(res => res.json())
+		updateUserFromApi(evt.detail)
 			.then(res => {
 				userUpdating = false;
 				if (res.success) {
 					queryUser();
 				} else {
-					userRequestError = res.errorDescription;
+					userRequestError = (res as ErrorResponse<LockerError>).error.name;
+					console.error((res as ErrorResponse<LockerError>).error);
 				}
 			})
 			.catch(err => {
@@ -80,16 +78,14 @@
 
 	function batchPutUser(evt: CustomEvent<User[]>) {
 		userUpdating = true;
-		fetchWithAuth(variables.baseUrl + '/api/v1/user/batch/put', {
-			method: 'POST',
-			body: JSON.stringify(evt.detail)
-		}).then(res => res.json())
+		batchPutUserFromApi(evt.detail)
 			.then(res => {
 				userUpdating = false;
 				if (res.success) {
 					queryUser();
 				} else {
-					userRequestError = res.errorDescription;
+					userRequestError = (res as ErrorResponse<LockerError>).error.name;
+					console.error((res as ErrorResponse<LockerError>).error);
 				}
 			})
 			.catch(err => {
@@ -100,16 +96,14 @@
 
 	function batchDeleteUser(evt: CustomEvent<string[]>) {
 		userUpdating = true;
-		fetchWithAuth(variables.baseUrl + '/api/v1/user/batch/delete', {
-			method: 'POST',
-			body: JSON.stringify(evt.detail)
-		}).then(res => res.json())
+		batchDeleteUserFromApi(evt.detail)
 			.then(res => {
 				userUpdating = false;
 				if (res.success) {
 					queryUser();
 				} else {
-					userRequestError = res.errorDescription;
+					userRequestError = (res as ErrorResponse<LockerError>).error.name;
+					console.error((res as ErrorResponse<LockerError>).error);
 				}
 			})
 			.catch(err => {
@@ -160,8 +154,8 @@
 		{#if $user && (!$user.department || $user.isAdmin)}
 			{#if selectedTab === "user"}
 				{#await userPromise}
-					<div class='user-screen-wrap'>
-						<div class='title'>
+					<div class='my-8 md:mx-8 flex flex-col gap-3 w-auto items-stretch'>
+						<div class='mx-6 md:mx-0 flex flex-wrap w-full'>
 							<h3>사용자 설정</h3>
 						</div>
 						<LoadingScreen class='min-h-[32rem] md:rounded-md' />
@@ -171,8 +165,8 @@
 												on:user:batchDelete={batchDeleteUser}
 												updating={userUpdating} error={userRequestError} {users} />
 				{:catch err}
-					<div class='user-screen-wrap'>
-						<div class='title'>
+					<div class='my-8 md:mx-8 flex flex-col gap-3 w-auto items-stretch'>
+						<div class='mx-6 md:mx-0 flex flex-wrap w-full'>
 							<h3 class='mb-1'>사용자 설정</h3>
 						</div>
 						<ErrorScreen class='min-h-[32rem] md:rounded-md' />
@@ -190,41 +184,3 @@
 		{/if}
 	</div>
 </NavigationShell>
-
-<style>
-    .root {
-        @apply flex flex-col md:flex-row items-stretch;
-    }
-
-    .side-wrap {
-        @apply bg-gray-200 w-full md:min-w-[380px] md:w-[380px] flex flex-col justify-between min-h-screen px-10;
-    }
-
-    .content {
-        @apply flex flex-col justify-evenly grow;
-    }
-
-    hr {
-        @apply h-0.5 mx-8 bg-gray-400;
-    }
-
-    .dashboard {
-        @apply grow h-screen md:overflow-y-scroll bg-gray-100;
-    }
-
-    .user-screen-wrap {
-        @apply my-8 md:mx-8 flex flex-col gap-3 w-auto items-stretch;
-    }
-
-    .user-screen-wrap .title {
-        @apply mx-6 md:mx-0 flex flex-wrap w-full;
-    }
-
-    .logo {
-        @apply pt-8;
-    }
-
-    .footer {
-        @apply pb-4 flex flex-wrap justify-between;
-    }
-</style>

--- a/packages/client/src/routes/admin/+page.svelte
+++ b/packages/client/src/routes/admin/+page.svelte
@@ -13,7 +13,7 @@
 	import ContentSettings from '../../icons/ContentSettings.svelte';
 	import { browser } from '$app/env';
 	import { deleteAuthorization } from '$lib/auth';
-	import { queryUser as queryUserFromApi, updateUser as updateUserFromApi, batchPutUser as batchPutUserFromApi, batchDeleteUser as batchDeleteUserFromApi } from '$lib/api/user';
+	import { apiQueryUser, apiUpdateUser, apiBatchPutUser, apiBatchDeleteUser } from '$lib/api/user';
 	import LoadingScreen from '../../components/atom/LoadingScreen.svelte';
 	import ErrorScreen from '../../components/atom/ErrorScreen.svelte';
 	import Skeleton from '../../components/atom/Skeleton.svelte';
@@ -46,7 +46,7 @@
 	}
 
 	function queryUser() {
-		userPromise = queryUserFromApi()
+		userPromise = apiQueryUser()
 			.then((res) => {
 				if (res.success) {
 					return res.result;
@@ -60,7 +60,7 @@
 
 	function updateUser(evt: CustomEvent<UserUpdateRequest>) {
 		userUpdating = true;
-		updateUserFromApi(evt.detail)
+		apiUpdateUser(evt.detail)
 			.then(res => {
 				userUpdating = false;
 				if (res.success) {
@@ -78,7 +78,7 @@
 
 	function batchPutUser(evt: CustomEvent<User[]>) {
 		userUpdating = true;
-		batchPutUserFromApi(evt.detail)
+		apiBatchPutUser(evt.detail)
 			.then(res => {
 				userUpdating = false;
 				if (res.success) {
@@ -96,7 +96,7 @@
 
 	function batchDeleteUser(evt: CustomEvent<string[]>) {
 		userUpdating = true;
-		batchDeleteUserFromApi(evt.detail)
+		apiBatchDeleteUser(evt.detail)
 			.then(res => {
 				userUpdating = false;
 				if (res.success) {

--- a/packages/client/src/routes/admin/+page.svelte
+++ b/packages/client/src/routes/admin/+page.svelte
@@ -37,8 +37,11 @@
 
 	// 사용자의 세션이 잘못되었을 경우, 세션 삭제 후 메인 페이지로 이동
 	$: if ($user && !$user.success && browser) {
-		deleteAuthorization();
-		window.location.href = '/';
+		const error = ($user as ErrorResponse<LockerError>).error;
+		if(error.code === 401 || error.code === 403) {
+			deleteAuthorization();
+			window.location.href = '/';
+		}
 	}
 
 	function closeSidebarMenu() {
@@ -53,9 +56,6 @@
 				}
 				throw (res as ErrorResponse<LockerError>).error;
 			})
-			.catch((err) => {
-				console.error(err);
-			});
 	}
 
 	function updateUser(evt: CustomEvent<UserUpdateRequest>) {
@@ -119,7 +119,7 @@
 
 <NavigationShell bind:sidebarCollapsed collapsable={innerWidth && innerWidth <= 768}>
 	<section class='flex flex-col gap-1' slot='navigation_content'>
-		{#if $user?.success}
+		{#if $user && $user.success}
 			<h3>설정</h3>
 			<SelectionListItemGroup bind:selectedIndex={selectedTabIndex}>
 				<SelectionListItem on:click={closeSidebarMenu} class='flex justify-between items-center' id='user'>
@@ -151,7 +151,7 @@
 		</Button>
 	</section>
 	<div class='h-screen'>
-		{#if $user?.success && (!$user.result.department || $user.result.isAdmin)}
+		{#if $user && $user.success && (!$user.result.department || $user.result.isAdmin)}
 			{#if selectedTab === "user"}
 				{#await userPromise}
 					<div class='my-8 md:mx-8 flex flex-col gap-3 w-auto items-stretch'>

--- a/packages/client/src/routes/admin/+page.svelte
+++ b/packages/client/src/routes/admin/+page.svelte
@@ -36,7 +36,7 @@
 	let innerWidth = 0;
 
 	// 사용자의 세션이 잘못되었을 경우, 세션 삭제 후 메인 페이지로 이동
-	$: if ($user === null && browser) {
+	$: if ($user && !$user.success && browser) {
 		deleteAuthorization();
 		window.location.href = '/';
 	}
@@ -119,7 +119,7 @@
 
 <NavigationShell bind:sidebarCollapsed collapsable={innerWidth && innerWidth <= 768}>
 	<section class='flex flex-col gap-1' slot='navigation_content'>
-		{#if $user}
+		{#if $user?.success}
 			<h3>설정</h3>
 			<SelectionListItemGroup bind:selectedIndex={selectedTabIndex}>
 				<SelectionListItem on:click={closeSidebarMenu} class='flex justify-between items-center' id='user'>
@@ -151,7 +151,7 @@
 		</Button>
 	</section>
 	<div class='h-screen'>
-		{#if $user && (!$user.department || $user.isAdmin)}
+		{#if $user?.success && (!$user.result.department || $user.result.isAdmin)}
 			{#if selectedTab === "user"}
 				{#await userPromise}
 					<div class='my-8 md:mx-8 flex flex-col gap-3 w-auto items-stretch'>
@@ -177,7 +177,7 @@
 			{:else if selectedTab === "department"}
 				<DepartmentSettings />
 			{/if}
-		{:else if !$user}
+		{:else if $user === undefined}
 			<LoadingScreen class='min-h-[480px]' />
 		{:else}
 			<ErrorScreen class='min-h-[480px]' errorMessage='권한이 부족하여 접근하실 수 없습니다.' />

--- a/packages/client/src/routes/callback/+page.svelte
+++ b/packages/client/src/routes/callback/+page.svelte
@@ -10,13 +10,14 @@
 	import Navigation from '../../components/molecule/Navigation.svelte';
 	import NavigationContent from '../../components/atom/NavigationContent.svelte';
 	import PageTitle from '../../components/atom/PageTitle.svelte';
+	import { apiSsuLogin } from '$lib/api/auth';
 
 	let result;
 	let id;
 
 	if (browser) {
 		result = new URLSearchParams(window.location.search).get('result');
-		id = fetch(variables.baseUrl + '/api/v1/auth/ssu_login?result=' + encodeURIComponent(result)).then((res) => res.json());
+		id = apiSsuLogin(result);
 		id.then((data) => {
 			const result: AccessTokenInfo = data.result;
 			document.cookie = `locker_session=${encodeURIComponent(result.accessToken)}; path=/; domain=${window.location.hostname}; max-age=${result.expiresIn}; samesite=lax`;

--- a/packages/client/src/routes/logout/+page.svelte
+++ b/packages/client/src/routes/logout/+page.svelte
@@ -11,13 +11,14 @@
 	import NavigationContent from '../../components/atom/NavigationContent.svelte';
 	import PageTitle from '../../components/atom/PageTitle.svelte';
 	import { fetchWithAuth } from '$lib/auth';
+	import { apiLogout } from '$lib/api/auth';
 
 	let result;
 	let id;
 
 	if (browser) {
 		result = new URLSearchParams(window.location.search).get('result');
-		id = fetchWithAuth(variables.baseUrl + '/api/v1/auth/logout').then((res) => res.json());
+		id = apiLogout();
 		id.then((data) => {
 			document.cookie = `locker_session=; path=/; domain=${window.location.hostname}; max-age=-9999999; samesite=lax`;
 			window.location.href = '/';

--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -137,7 +137,7 @@ paths:
                   result:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Locker'
+                      $ref: '#/components/schemas/ReservedLockerResponse'
         '403':
           description: 권한 부족
           content:
@@ -225,9 +225,17 @@ paths:
                     type: boolean
                   result:
                     type: object
+                    required:
+                      - id
+                      - lockerId
                     properties:
+                      id:
+                        type: string
                       lockerId:
                         type: string
+                      claimedUntil:
+                        type: string
+                        format: date-time
         '400':
           description: '`until` 값이 올바르지 않을 경우'
           content:
@@ -314,7 +322,12 @@ paths:
                     type: boolean
                   result:
                     type: object
+                    required:
+                      - id
+                      - lockerId
                     properties:
+                      id:
+                        type: string
                       lockerId:
                         type: string
         '403':
@@ -876,9 +889,9 @@ components:
         expiresIn:
           type: integer
           format: int32
-    Locker:
-      title: Locker
-      description: 사물함 정보입니다.
+    ReservedLockerResponse:
+      title: ReservedLockerResponse
+      description: 대여된 사물함 정보입니다.
       type: object
       required:
         - lockerId
@@ -889,9 +902,9 @@ components:
           type: string
           description: 이 사물함을 사용중인 사용자의 학번입니다.
         claimedUntil:
-          type: number
-          format: int32
-          description: 이 사물함을 사용하는 기한을 표현한 UNIX TIMESTAMP입니다. 없다면 무기한으로 사용중인 사물함입니다.
+          type: string
+          format: date-time
+          description: 이 사물함을 사용하는 기한을 표현한 ISODate 입니다. 이 값이 없다면 무기한입니다.
     LockerCountResponse:
       title: LockerCountResponse
       description: 사물함 갯수 요청 시 반환하는 형식입니다.

--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -444,12 +444,9 @@ paths:
                 type: object
                 required:
                   - success
-                  - result
                 properties:
                   success:
                     type: boolean
-                  result:
-                    $ref: '#/components/schemas/UserUpdateRequest'
         '400':
           description: 요청 형식이 잘못되었을 때
           content:
@@ -602,12 +599,9 @@ paths:
                 type: object
                 required:
                   - success
-                  - result
                 properties:
                   success:
                     type: boolean
-                  result:
-                    $ref: '#/components/schemas/UserBatchPutRequest'
         '400':
           description: 요청 형식이 잘못되었을 때
           content:
@@ -654,12 +648,9 @@ paths:
                 type: object
                 required:
                   - success
-                  - result
                 properties:
                   success:
                     type: boolean
-                  result:
-                    $ref: '#/components/schemas/UserBatchDeleteRequest'
         '400':
           description: 요청 형식이 잘못되었을 때
           content:

--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -384,7 +384,7 @@ paths:
                   success:
                     type: boolean
                   result:
-                    $ref: '#/components/schemas/User'
+                    $ref: '#/components/schemas/UserResponse'
         '403':
           description: 권한 부족
           content:
@@ -542,7 +542,7 @@ paths:
                   result:
                     type: array
                     items:
-                      $ref: '#/components/schemas/User'
+                      $ref: '#/components/schemas/UserResponse'
         '403':
           description: 권한 부족
           content:
@@ -696,7 +696,7 @@ paths:
                       - SERVICE
                     properties:
                       SERVICE:
-                        $ref: '#/components/schemas/Config'
+                        $ref: '#/components/schemas/ConfigResponse'
         '404':
           description: 설정을 찾을 수 없을 경우
           content:
@@ -915,8 +915,8 @@ components:
         until:
           type: string
           format: date-time
-    User:
-      title: User
+    UserResponse:
+      title: UserResponse
       description: 사용자 정보입니다.
       type: object
       required:
@@ -978,9 +978,9 @@ components:
       description: 사용자 정보를 일괄 삽입하고자 할 때 사용합니다.
       type: array
       items:
-        $ref: '#/components/schemas/User'
-    Config:
-      title: Config
+        $ref: '#/components/schemas/UserResponse'
+    ConfigResponse:
+      title: ConfigResponse
       description: 서비스의 설정 정보입니다.
       type: object
       required:

--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -94,7 +94,12 @@ paths:
                   success:
                     type: boolean
                   result:
-                    type: string
+                    type: object
+                    required:
+                      - accessToken
+                    properties:
+                      accessToken:
+                        type: string
         '401':
           description: 로그인 상태가 아닐 경우
           content:
@@ -735,12 +740,9 @@ paths:
                 type: object
                 required:
                   - success
-                  - result
                 properties:
                   success:
                     type: boolean
-                  result:
-                    $ref: '#/components/schemas/ConfigUpdateRequest'
         '400':
           description: 요청 형식이 잘못되었을 때
           content:
@@ -792,7 +794,7 @@ paths:
                   success:
                     type: boolean
                   result:
-                    $ref: '#/components/schemas/ConfigDeleteRequest'
+                    type: string
         '400':
           description: 요청 형식이 잘못되었을 때
           content:

--- a/packages/server/src/auth/handler/logout.ts
+++ b/packages/server/src/auth/handler/logout.ts
@@ -12,6 +12,9 @@ export const logoutHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await revokeToken(payload.aud as string, token);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsLockerError(e, new UnauthorizedError("Can't logout when not logged in", { token }));
+		return responseAsLockerError(
+			e,
+			new UnauthorizedError("Can't logout when not logged in", { token })
+		);
 	}
 };

--- a/packages/server/src/auth/handler/ssu_login.ts
+++ b/packages/server/src/auth/handler/ssu_login.ts
@@ -69,6 +69,6 @@ export const ssuLoginHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return errorResponse(new UnauthorizedError('No result parameter provided'));
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/config/data.ts
+++ b/packages/server/src/config/data.ts
@@ -95,8 +95,8 @@ function toConfigDao(data: Config): ConfigDao {
 		type: { S: 'config' },
 		id: { S: data.id },
 		n: { S: data.name },
-		...(data.activateFrom && { aF: { S: data.activateFrom } }),
-		...(data.activateTo && { aT: { S: data.activateTo } })
+		...(data.activateFrom && { aF: { S: data.activateFrom.toISOString() } }),
+		...(data.activateTo && { aT: { S: data.activateTo.toISOString() } })
 	};
 }
 
@@ -104,8 +104,8 @@ function fromConfigDao(dao: ConfigDao): Config {
 	return {
 		id: dao.id?.S ?? 'SERVICE',
 		name: dao.n?.S ?? 'IT대학 사물함 시스템',
-		...(dao.aF && { activateFrom: dao.aF.S }),
-		...(dao.aT && { activateTo: dao.aT.S })
+		...(dao.aF && { activateFrom: new Date(dao.aF.S) }),
+		...(dao.aT && { activateTo: new Date(dao.aT.S) })
 	};
 }
 
@@ -140,6 +140,14 @@ function fromDepartmentConfigDao(dao: DepartmentConfigDao): DepartmentConfig {
 	return {
 		...fromConfigDao(dao),
 		...(dao.c && { contact: dao.c.S })
+	};
+}
+
+export function toConfigResponse(config: Config): ConfigResponse {
+	return {
+		...config,
+		...(config.activateFrom && { activateFrom: config.activateFrom.toISOString() }),
+		...(config.activateTo && { activateTo: config.activateTo })
 	};
 }
 

--- a/packages/server/src/config/data.ts
+++ b/packages/server/src/config/data.ts
@@ -147,7 +147,7 @@ export function toConfigResponse(config: Config): ConfigResponse {
 	return {
 		...config,
 		...(config.activateFrom && { activateFrom: config.activateFrom.toISOString() }),
-		...(config.activateTo && { activateTo: config.activateTo })
+		...(config.activateTo && { activateTo: config.activateTo.toISOString() })
 	};
 }
 

--- a/packages/server/src/config/handler/delete.ts
+++ b/packages/server/src/config/handler/delete.ts
@@ -25,6 +25,6 @@ export const deleteConfigHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await deleteConfig(data.id);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/config/handler/get.ts
+++ b/packages/server/src/config/handler/get.ts
@@ -1,11 +1,11 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
-import { queryConfig } from '../data';
+import { queryConfig, toConfigResponse } from '../data';
 import { responseAsLockerError } from '../../util/error';
 
 export const getConfigHandler: APIGatewayProxyHandler = async () => {
 	try {
-		const configs = await queryConfig();
+		const configs = (await queryConfig()).map(toConfigResponse);
 		return createResponse(200, {
 			success: true,
 			result: configs

--- a/packages/server/src/config/handler/get.ts
+++ b/packages/server/src/config/handler/get.ts
@@ -11,6 +11,6 @@ export const getConfigHandler: APIGatewayProxyHandler = async () => {
 			result: configs
 		});
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/config/handler/update.ts
+++ b/packages/server/src/config/handler/update.ts
@@ -23,6 +23,6 @@ export const updateConfigHandler: APIGatewayProxyHandler = async (event) => {
 		await updateConfig(data);
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/claim.ts
+++ b/packages/server/src/locker/handler/claim.ts
@@ -18,10 +18,10 @@ export const claimLockerHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
 	let data: {
 		lockerId: string;
-		until?: number;
+		until?: string;
 	};
 	try {
-		data = JSON.parse(event.body) as { lockerId: string; until?: number };
+		data = JSON.parse(event.body) as { lockerId: string; until?: string };
 	} catch {
 		return errorResponse(new BadRequestError('Request body is malformed JSON'));
 	}
@@ -53,7 +53,7 @@ export const claimLockerHandler: APIGatewayProxyHandler = async (event) => {
 		const until = data?.until;
 		let res: ClaimLockerResponse;
 		if (until) {
-			res = await claimLocker(id, token, blockedDepartments, lockerId, until);
+			res = await claimLocker(id, token, blockedDepartments, lockerId, new Date(until).getTime());
 		} else {
 			res = await claimLocker(id, token, blockedDepartments, lockerId);
 		}

--- a/packages/server/src/locker/handler/claim.ts
+++ b/packages/server/src/locker/handler/claim.ts
@@ -51,7 +51,7 @@ export const claimLockerHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		const lockerId = data.lockerId;
 		const until = data?.until;
-		let res: { id: string; lockerId: string; claimedUntil: number };
+		let res: ClaimLockerResponse;
 		if (until) {
 			res = await claimLocker(id, token, blockedDepartments, lockerId, until);
 		} else {

--- a/packages/server/src/locker/handler/claim.ts
+++ b/packages/server/src/locker/handler/claim.ts
@@ -59,6 +59,6 @@ export const claimLockerHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/count.ts
+++ b/packages/server/src/locker/handler/count.ts
@@ -23,6 +23,6 @@ export const getClaimedLockerCountHandler: APIGatewayProxyHandler = async () => 
 			result
 		});
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/query.ts
+++ b/packages/server/src/locker/handler/query.ts
@@ -21,6 +21,6 @@ export const queryClaimedLockersHandler: APIGatewayProxyHandler = async (event) 
 			result
 		});
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/locker/handler/query.ts
+++ b/packages/server/src/locker/handler/query.ts
@@ -12,7 +12,10 @@ export const queryClaimedLockersHandler: APIGatewayProxyHandler = async (event) 
 		const payload = verifyPayload(token);
 		const id = payload.aud as string;
 		await assertAccessible(id, token, showId);
-		const result = await queryLockers('', showId);
+		const result = (await queryLockers('', showId)).map((locker) => ({
+			...locker,
+			...(locker.claimedUntil && { claimedUntil: locker.claimedUntil.toISOString() })
+		}));
 		return createResponse(200, {
 			success: true,
 			result

--- a/packages/server/src/locker/handler/unclaim.ts
+++ b/packages/server/src/locker/handler/unclaim.ts
@@ -19,6 +19,6 @@ export const unclaimLockerHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await unclaimLocker(id, token, blockedDepartments);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/data.ts
+++ b/packages/server/src/user/data.ts
@@ -21,8 +21,10 @@ export const fromUserDao = (dao: UserDao): User => ({
 	isAdmin: dao.iA?.BOOL ?? false,
 	department: dao.d?.S,
 	...(dao.lockerId?.S && { lockerId: dao.lockerId?.S }),
-	...(dao.cU?.N && { claimedUntil: parseInt(dao.cU?.N) })
+	...(dao.cU?.N &&
+		parseInt(dao.cU?.N ?? '-1') >= 0 && { claimedUntil: new Date(parseInt(dao.cU?.N)) })
 });
+
 export const toUserDao = (user: User): UserDao => ({
 	type: { S: 'user' },
 	id: { S: `${user.id}` },
@@ -30,8 +32,15 @@ export const toUserDao = (user: User): UserDao => ({
 	iA: { BOOL: user.isAdmin },
 	d: { S: user.department },
 	...(user.lockerId && { lockerId: { S: user.lockerId } }),
-	...(user.claimedUntil && { cU: { N: `${user.claimedUntil}` } })
+	...(user.claimedUntil && { cU: { N: `${user.claimedUntil.getTime()}` } })
 });
+
+export function toUserResponse(user: User): UserResponse {
+	return {
+		...user,
+		...(user.claimedUntil && { claimedUntil: user.claimedUntil.toISOString() })
+	};
+}
 
 export const getUser = async function (id: string): Promise<User> {
 	const req: GetItemInput = {

--- a/packages/server/src/user/handler/batch/delete.ts
+++ b/packages/server/src/user/handler/batch/delete.ts
@@ -38,7 +38,7 @@ export const batchDeleteUserHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsLockerError(e, new InternalError('Internal error'), {
+		return responseAsLockerError(e, new InternalError('Internal error'), {
 			failedData: JSON.stringify(data.slice(i, data.length))
 		});
 	}

--- a/packages/server/src/user/handler/batch/put.ts
+++ b/packages/server/src/user/handler/batch/put.ts
@@ -38,7 +38,7 @@ export const batchPutUserHandler: APIGatewayProxyHandler = async (event) => {
 		}
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsLockerError(e, new InternalError('Internal error'), {
+		return responseAsLockerError(e, new InternalError('Internal error'), {
 			failedData: JSON.stringify(data.slice(i, data.length))
 		});
 	}

--- a/packages/server/src/user/handler/delete.ts
+++ b/packages/server/src/user/handler/delete.ts
@@ -23,6 +23,6 @@ export const deleteUserHandler: APIGatewayProxyHandler = async (event) => {
 		const res = await deleteUser(data.id);
 		return createResponse(200, { success: true, result: res });
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/handler/get.ts
+++ b/packages/server/src/user/handler/get.ts
@@ -1,6 +1,6 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
-import { getUser } from '../data';
+import { getUser, toUserResponse } from '../data';
 import { responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
@@ -8,7 +8,7 @@ export const getUserHandler: APIGatewayProxyHandler = async (event) => {
 	const token = (event.headers.Authorization ?? '').replace('Bearer ', '');
 	try {
 		const id = verifyPayload(token).aud as string;
-		const result = await getUser(id);
+		const result = toUserResponse(await getUser(id));
 		return createResponse(200, {
 			success: true,
 			result

--- a/packages/server/src/user/handler/get.ts
+++ b/packages/server/src/user/handler/get.ts
@@ -14,6 +14,6 @@ export const getUserHandler: APIGatewayProxyHandler = async (event) => {
 			result
 		});
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/handler/query.ts
+++ b/packages/server/src/user/handler/query.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyHandler } from 'aws-lambda';
 import { createResponse } from '../../common';
 import { assertAccessible } from '../../auth/data';
-import { queryUser } from '../data';
+import { queryUser, toUserResponse } from '../data';
 import { responseAsLockerError } from '../../util/error';
 import { verifyPayload } from '../../util/access';
 
@@ -11,7 +11,7 @@ export const queryUserHandler: APIGatewayProxyHandler = async (event) => {
 	try {
 		const id = verifyPayload(token).aud as string;
 		await assertAccessible(id, token, true);
-		const result = await queryUser(startsWith);
+		const result = (await queryUser(startsWith)).map(toUserResponse);
 		return createResponse(200, {
 			success: true,
 			result

--- a/packages/server/src/user/handler/query.ts
+++ b/packages/server/src/user/handler/query.ts
@@ -17,6 +17,6 @@ export const queryUserHandler: APIGatewayProxyHandler = async (event) => {
 			result
 		});
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/src/user/handler/update.ts
+++ b/packages/server/src/user/handler/update.ts
@@ -23,6 +23,6 @@ export const updateUserHandler: APIGatewayProxyHandler = async (event) => {
 		await updateUser(data);
 		return createResponse(200, { success: true });
 	} catch (e) {
-		responseAsLockerError(e);
+		return responseAsLockerError(e);
 	}
 };

--- a/packages/server/template.yaml
+++ b/packages/server/template.yaml
@@ -22,7 +22,7 @@ Parameters:
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 10
+    Timeout: 30
     Environment:
       Variables:
         TABLE_NAME: !Ref TableName

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -13,8 +13,19 @@ type User = {
 	isAdmin: boolean;
 	department: string;
 	lockerId?: string;
-	claimedUntil?: number;
+	claimedUntil?: Date;
 };
+
+type UserResponse = {
+	id: string;
+	name: string;
+	isAdmin: boolean;
+	department: string;
+	lockerId?: string;
+	claimedUntil?: string;
+};
+
+type UserPutRequest = UserResponse;
 
 type UserUpdateRequest = {
 	id: string;
@@ -49,6 +60,13 @@ type AccessTokenInfo = {
 type Config = {
 	id: string;
 	name: string;
+	activateFrom?: Date;
+	activateTo?: Date;
+};
+
+type ConfigResponse = {
+	id: string;
+	name: string;
 	activateFrom?: string;
 	activateTo?: string;
 };
@@ -63,12 +81,22 @@ type DepartmentConfig = Config & {
 	contact?: string;
 };
 
+type DepartmentConfigResponse = ConfigResponse & {
+	contact?: string;
+};
+
 type DepartmentConfigDao = DaoData &
 	ConfigDao & {
 		c?: { S: string };
 	};
 
 type ServiceConfig = Config & {
+	buildings: {
+		[buildingId: string]: Building;
+	};
+};
+
+type ServiceConfigResponse = ConfigResponse & {
 	buildings: {
 		[buildingId: string]: Building;
 	};
@@ -206,9 +234,9 @@ type InternalError = LockerError & {
 
 /* Error Definition */
 
-type LockerError = {
-	code: string;
+interface LockerError {
+	code: number;
 	name: string;
 	message?: string;
 	additionalInfo?: Record<string, unknown>;
-};
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -26,6 +26,7 @@ type UserResponse = {
 };
 
 type UserPutRequest = UserResponse;
+type BatchUserPutRequest = UserPutRequest[];
 
 type UserUpdateRequest = {
 	id: string;
@@ -53,6 +54,26 @@ type AccessTokenInfo = {
 	accessToken: string;
 	tokenType: 'Bearer';
 	expiresIn: number;
+};
+
+/* Locker Definition */
+
+type ReservedLocker = {
+	id?: string;
+	lockerId: string;
+	claimedUntil?: Date;
+};
+
+type ReservedLockerResponse = {
+	id?: string;
+	lockerId: string;
+	claimedUntil?: string;
+};
+type ClaimLockerResponse = ReservedLockerResponse;
+
+type UnclaimLockerResponse = {
+	id: string;
+	lockerId: string;
 };
 
 /* Config Definition */

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -187,14 +187,14 @@ type Response = {
 	success: boolean;
 };
 
-type SuccessResponse = {
+type SuccessResponse<T> = {
 	success: true;
-	result?: unknown;
+	result?: T;
 };
 
-type ErrorResponse = {
+type ErrorResponse<E extends LockerError> = {
 	success: false;
-	error: LockerError;
+	error: E;
 };
 
 type BadRequestError = LockerError & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       typescript: ^4.7.4
       vite: ^3.0.0
       xlsx: https://cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz
+      zod: ^3.18.0
     dependencies:
       lodash.isequal: 4.5.0
       xlsx: '@cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz'
@@ -61,10 +62,11 @@ importers:
       svelte: 3.48.0
       svelte-check: 2.8.0_x4nqt44wnukty73um2kz4qdzya
       svelte-preprocess: 4.10.7_3zakmmfkrfgnjsltlgxikg2if4
-      tailwindcss: 3.1.7
+      tailwindcss: 3.1.7_postcss@8.4.14
       tslib: 2.4.0
       typescript: 4.7.4
       vite: 3.0.4
+      zod: 3.18.0
 
   packages/server:
     specifiers:
@@ -339,7 +341,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.1.7
+      tailwindcss: 3.1.7_postcss@8.4.14
     dev: true
 
   /@types/aws-lambda/8.10.101:
@@ -1633,7 +1635,7 @@ packages:
     dependencies:
       fast-glob: 3.2.11
       postcss: 8.4.14
-      tailwindcss: 3.1.7
+      tailwindcss: 3.1.7_postcss@8.4.14
     transitivePeerDependencies:
       - ts-node
     dev: true
@@ -3344,10 +3346,12 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /tailwindcss/3.1.7:
+  /tailwindcss/3.1.7_postcss@8.4.14:
     resolution: {integrity: sha512-r7mgumZ3k0InfVPpGWcX8X/Ut4xBfv+1O/+C73ar/m01LxGVzWvPxF/w6xIUPEztrCoz7axfx0SMdh8FH8ZvRQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -3690,6 +3694,10 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /zod/3.18.0:
+    resolution: {integrity: sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==}
     dev: true
 
   '@cdn.sheetjs.com/xlsx-0.18.10/xlsx-0.18.10.tgz':


### PR DESCRIPTION
> 관련 이슈: #47 #96 

# `zod` 활용 Schema Validation

## `$lib/api` 폴더
해당 파일은 API 요청을 편리하고, `type-safe` 하게 해주는 함수들이 모여있는 파일입니다.

해당 폴더 내부의 `auth`, `locker`, `config`, `user` 파일은 각각의 엔드포인트 경로를 나타내며, 내부의 `api` 로 시작하는 함수를 호출함으로써 엔드포인트를 호출할 수 있습니다.

이 함수들은 `SuccessResponse` 혹은 `ErrorResponse` 를 반환하며, 해당 Response 에서 어떤 정보, 어떤 오류를 반환하는지는  TypeScript 정의를 통해 확인할 수 있습니다.
함수 사용자는 함수의 반환값 중 `success` field 가 참인지 거짓인지 확인하여 해당 Response 가 `SuccessResponse` 인지, `ErrorResponse` 인지 확인할 수 있으며, 이에 따라 적절한 처리를 할 수 있습니다.

일반적으로 반환될 수 있는 오류는 throw 되지 않고 ErrorResponse 형식으로 반환되며, 이는 반드시 클라이언트 단에서 핸들링 해 주시기 바랍니다. 이외 오류는 예외로 취급하여 다시 리퀘스트를 보내시거나 오류 메시지 표시를 진행해주시면 됩니다.

## BREAKING: `store` 의 사용 방법 변경
위 API 함수를 이용하여 `store` 내부의 `$config`, `$user` 를 재작업 하였습니다. 이제 해당 store들의 반환값은 각각 `SuccessResponse<Config[]> | ErrorResponse<LockerError> | undefined`, `SuccessResponse<User> | ErrorResponse<LockerError> | undefined` 입니다.

오류 확인시 `null` 확인 대신 `success` 값이 참이면 요청 성공, 거짓이면 오류가 발생한 것으로, 이제 `$config`, `$user` 등으로 직접 값을 가져오는 것이 아닌, `$config.success`, `$user.success` 등으로 성공 여부를 확인하고, `$config.result`, `$user.result` 로 값을 가져와야 합니다. (기존에 값이 로드되지 않았을 때에는 `undefined` 인 점은 동일하므로, `$config` 가 로드되었는지, `$config.success` 가 참인지 두 가지 전부 다 확인하셔야 합니다.)

해당 변경사항 확인하시고 리뷰 후 머지 부탁드립니다.