### PR TITLE
`/locker/count` 가 건물 번호도 포함하도록 수정

### DIFF
--- a/packages/server/api.yaml
+++ b/packages/server/api.yaml
@@ -188,6 +188,17 @@ paths:
                     type: boolean
                   result:
                     $ref: '#/components/schemas/LockerCountResponse'
+              example:
+                success: true
+                result:
+                  G:
+                    21:
+                      B1: 50
+                      4: 10
+                      5: 100
+                  A:
+                    05:
+                      B1: 100
         '404':
           description: 사물함을 찾을 수 없을 경우
           content:
@@ -906,9 +917,12 @@ components:
         departmentId:
           type: object
           properties:
-            floor:
-              type: number
-              format: int32
+            buildingNum:
+              type: object
+              properties:
+                floor:
+                  type: number
+                  format: int32
     LockerClaimRequest:
       title: LockerClaimRequest
       description: 사물함 대여 요청입니다.

--- a/packages/server/src/locker/handler/count.ts
+++ b/packages/server/src/locker/handler/count.ts
@@ -11,11 +11,12 @@ export const getClaimedLockerCountHandler: APIGatewayProxyHandler = async () => 
 		const lockers = await queryLockers();
 		const result = lockers.reduce<LockerCountResponse>((acc, cur) => {
 			const dept = getLockerDepartment(config, cur.lockerId);
-			const parsedLockerId = cur.lockerId.split('-');
-			const lockerFloor = parsedLockerId[1];
+			const [buildingId, lockerFloor] = cur.lockerId.split('-');
 			if (!acc[dept]) acc[dept] = {};
-			if (typeof acc[dept][lockerFloor] !== 'number') acc[dept][lockerFloor] = 0;
-			acc[getLockerDepartment(config, cur.lockerId)][lockerFloor] += 1;
+			if (!acc[dept][buildingId]) acc[buildingId] = {};
+			if (typeof acc[dept][buildingId][lockerFloor] !== 'number')
+				acc[dept][buildingId][lockerFloor] = 0;
+			acc[getLockerDepartment(config, cur.lockerId)][buildingId][lockerFloor] += 1;
 			return acc;
 		}, {});
 		return createResponse(200, {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -198,7 +198,9 @@ type ConfigDeleteRequest = {
 
 type LockerCountResponse = {
 	[departmentId: string]: {
-		[floor: string]: number;
+		[buildingNum: string]: {
+			[floor: string]: number;
+		};
 	};
 };
 


### PR DESCRIPTION
> 관련 이슈: #161

# 변경사항

`/locker/count` 의 응답이 다음과 같이 변경:

기존:
```json
{
  "학부ID": {
    "층": 123,
    "층": 123,
    ...
  },
  "학부ID": {
    "층": 123,
    ...
  }
}
```

변경:
```json
{
  "학부ID": {
    "건물번호": {
      "층": 123,
      "층": 123,
      ...
    }
  }
}
```