### PR TITLE
서버에서 오류를 인식하지 못해 무조건 `500`을 응답하는 오류 수정

### DIFF
--- a/packages/server/src/util/error.ts
+++ b/packages/server/src/util/error.ts
@@ -23,6 +23,7 @@ export class LockerError extends Error {
 		this.name = name;
 		this.message = message;
 		this.additionalInfo = additionalInfo;
+		this.isLockerError = true;
 	}
 }
 
@@ -69,6 +70,7 @@ export class InternalError extends LockerError {
 }
 
 export function isLockerError(error: unknown) {
+	console.log(typeof error, (error as LockerError).isLockerError);
 	return typeof error === 'object' && (error as LockerError)?.isLockerError;
 }
 

--- a/packages/server/src/util/error.ts
+++ b/packages/server/src/util/error.ts
@@ -70,7 +70,6 @@ export class InternalError extends LockerError {
 }
 
 export function isLockerError(error: unknown) {
-	console.log(typeof error, (error as LockerError).isLockerError);
 	return typeof error === 'object' && (error as LockerError)?.isLockerError;
 }
 


### PR DESCRIPTION
- 이제 오류 발생시 [OpenAPI](https://eatsteak.github.io/lockerweb) 과 동일하게 응답함