### PR TITLE
모바일 화면에서의 `Navigation` 레이아웃 조정

### DIFF
--- a/packages/client/src/components/molecule/Navigation.svelte
+++ b/packages/client/src/components/molecule/Navigation.svelte
@@ -61,12 +61,12 @@
 				 class:fixed={collapsable && !isOnTop}>
 		{#if !collapsable || !collapsed}
 			<nav transition:fly={{ y: -100, duration: 500 }}
-					 class='{navClass} px-10 flex flex-col bg-gray-200 grow overflow-y-auto shadow-md'
+					 class='{navClass} px-6 md:px-10 flex flex-col bg-gray-200 grow overflow-y-auto shadow-md'
 					 class:mb-2={collapsable}>
 				<slot />
 			</nav>
 		{/if}
-		<section bind:clientHeight={h} class='{headerClass} px-10 bg-gray-200 transition-all'
+		<section bind:clientHeight={h} class='{headerClass} px-6 md:px-10 bg-gray-200 transition-all'
 						 class:shadow-md={collapsable && collapsed} class:mb-2={collapsable && collapsed}>
 			<slot name='header' />
 		</section>

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -37,7 +37,7 @@
 		<NavigationHeader class='py-1 md:py-0 md:pt-10' slot='header'>
 			<slot name='navigation_header'>
 				<div class='flex flex-col grow items-start flex-wrap'>
-					<Soongsil class='w-20 h-20' />
+					<Soongsil class='w-12 h-12 md:w-20 md:h-20' />
 				</div>
 				{#if collapsable}
 					<div class='flex justify-center items-center'>

--- a/packages/client/src/components/molecule/NavigationShell.svelte
+++ b/packages/client/src/components/molecule/NavigationShell.svelte
@@ -34,7 +34,7 @@
 <Shell class={clazz} {navigationClass} {mainClass}>
 	<Navigation slot='navigation' class='flex-row w-full'
 							{collapsable} bind:collapsed={navigationCollapsed}>
-		<NavigationHeader class='md:pt-10' slot='header'>
+		<NavigationHeader class='py-1 md:py-0 md:pt-10' slot='header'>
 			<slot name='navigation_header'>
 				<div class='flex flex-col grow items-start flex-wrap'>
 					<Soongsil class='w-20 h-20' />

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -62,7 +62,7 @@
 		<slot name='navigation'>
 			<Navigation class='flex-row w-full h-full'>
 				<NavigationHeader class='py-1 md:py-0 md:pt-10' slot='header'>
-					<Soongsil class='w-20 h-20' />
+					<Soongsil class='w-12 h-12 md:w-20 md:h-20' />
 				</NavigationHeader>
 				<Divider class='my-6' />
 				<NavigationContent>

--- a/packages/client/src/components/molecule/Shell.svelte
+++ b/packages/client/src/components/molecule/Shell.svelte
@@ -61,7 +61,7 @@
 	<section class='{navigationClass} flex row w-full md:min-w-[380px] md:basis-[380px] md:h-screen'>
 		<slot name='navigation'>
 			<Navigation class='flex-row w-full h-full'>
-				<NavigationHeader class='md:py-10' slot='header'>
+				<NavigationHeader class='py-1 md:py-0 md:pt-10' slot='header'>
 					<Soongsil class='w-20 h-20' />
 				</NavigationHeader>
 				<Divider class='my-6' />


### PR DESCRIPTION
- 전체적인 x 마진 줄임(`px-10` -> `px-6`)
- y 마진 추가 (`py-1`)
- 숭실 로고 크기 조정 (`w-20 h-20` -> `w-12 h-12`)