### PR TITLE
`LockerList` 에 상하 마진 추가

### DIFF
--- a/packages/client/src/components/molecule/reserve/LockerList.svelte
+++ b/packages/client/src/components/molecule/reserve/LockerList.svelte
@@ -17,7 +17,8 @@
 
 </script>
 
-<div class='flex flex-col flex-wrap mt-2 ml-auto mr-auto' style={`width:${widthScale}rem; height:${heightScale}rem;`}>
+<div class='flex flex-col flex-wrap mt-8 mb-20 ml-auto mr-auto'
+		 style={`width:${widthScale}rem; height:${heightScale}rem;`}>
 	{#each lockers as { lockerId, disabled, reserved }, index}
 		<LockerItem class='ml-4 my-2' id={lockerId} disabled={disabled || reserved} on:click={() => selectedId = lockerId}
 								selected={selectedId === lockerId}


### PR DESCRIPTION
- 상하 마진을 추가하여 가독성 향상 및 선택 시 아래 뜨는 Alert 가 목록을 가리지 않도록 함