### PR TITLE
[fix] `Skeleton` 이 가변 크기를 가질 수 있도록 수정

### DIFF
--- a/packages/client/src/components/atom/Skeleton.svelte
+++ b/packages/client/src/components/atom/Skeleton.svelte
@@ -1,36 +1,36 @@
-<script lang="ts">
+<script lang='ts'>
 
-  let clazz = '';
-  export { clazz as class };
+	let clazz = '';
+	export { clazz as class };
 
-  let width: number;
-  let height: number;
+	let width: number;
+	let height: number;
 
 </script>
 
-<div class={`skeleton ${clazz}`} bind:clientWidth={width} bind:clientHeight={height} {...$$restProps}>
-  <div style:--widthSize={`${width*4*1.8}px`} style:--heightSize={`${height*4*3}px`} class="skeleton-inner-animation"></div>
+<div class='{clazz} relative cursor-progress overflow-hidden' bind:clientWidth={width} bind:clientHeight={height}
+		 {...$$restProps}>
+	<div style:--widthSize={`${width*4*1.8}px`} style:--heightSize={`${height*4*3}px`}
+			 class='absolute top-0 left-0 skeleton-inner-animation'></div>
 </div>
 
 <style>
-  .skeleton {
-    @apply cursor-progress overflow-hidden;
 
-  }
-  .skeleton-inner-animation {
-      width: var(--widthSize);
-      height: var(--heightSize);
-      background: linear-gradient(100deg, rgba(0, 0, 0, 0.01) 12%, rgba(255, 255, 255, 0.3) 18%, rgba(0, 0, 0, 0.01) 22%);
-      background-size: 110% 80%;
-      animation: loading 1.3s infinite;
-  }
-  @keyframes loading {
-      from {
-          background-position-x: 0;
-      }
-      to {
-          background-position-x: -1100%;
-      }
-  }
+    .skeleton-inner-animation {
+        width: var(--widthSize);
+        height: var(--heightSize);
+        background: linear-gradient(100deg, rgba(0, 0, 0, 0.01) 12%, rgba(255, 255, 255, 0.3) 18%, rgba(0, 0, 0, 0.01) 22%);
+        background-size: 110% 80%;
+        animation: loading 1.3s infinite;
+    }
+
+    @keyframes loading {
+        from {
+            background-position-x: 0;
+        }
+        to {
+            background-position-x: -1100%;
+        }
+    }
 
 </style>

--- a/packages/client/src/components/molecule/reserve/LockerReserveInfo.svelte
+++ b/packages/client/src/components/molecule/reserve/LockerReserveInfo.svelte
@@ -88,7 +88,7 @@
 				</div>
 			{:else}
 				<div class='p-8 w-full h-full flex justify-center items-center'>
-					<div class='w-full h-full rounded-xl bg-gray-300 animate-pulse'></div>
+					<Skeleton class='w-full h-full rounded-xl bg-gray-300' />
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
- 스켈레톤을 wrapping 하는 부모 엘리먼트의 크기를 프로그래밍적으로 크기가 변경되는 자식 엘리먼트의 크기에 영향을 받지 않도록 하여 가변 크기 구현