### PR TITLE
[feat] 학부별 예약 시간이 아니여도 로그인은 가능하도록 수정

### DIFF
--- a/packages/server/src/auth/handler/ssu_login.ts
+++ b/packages/server/src/auth/handler/ssu_login.ts
@@ -54,7 +54,7 @@ export const ssuLoginHandler: APIGatewayProxyHandler = async (event) => {
 			const accessToken = jwt.sign({ aud: id }, JWT_SECRET, {
 				expiresIn: 3600 * 1000
 			});
-			const issued = await issueToken(id, accessToken, blockedDepartments);
+			const issued = await issueToken(id, accessToken);
 			const left = Math.floor((issued.expires - Date.now()) / 1000);
 			const res = {
 				success: true,


### PR DESCRIPTION
> 관련 이슈: #250 
- 기존과 같이 `/locker/claim` 및 `/locker/unclaim` 은 불가
- 서버(백엔드)만 수정되었으므로 클라이언트 측 수정 필요