### PR TITLE
[fix] `LockerList` 의 margin 이 고르게 분배되도록 함

### DIFF
--- a/packages/client/src/components/molecule/reserve/LockerList.svelte
+++ b/packages/client/src/components/molecule/reserve/LockerList.svelte
@@ -15,12 +15,12 @@
 </script>
 
 <div
-	class='flex flex-col flex-wrap mt-8 mb-20 ml-auto mr-auto'
+	class='flex flex-col flex-wrap mt-8 mb-20 gap-4 mx-4'
 	style={`width:${widthScale}rem; height:${heightScale}rem;`}
 >
 	{#each lockers as { lockerId, disabled, reserved }, index}
 		<LockerItem
-			class='ml-4 my-2'
+			class='my-2'
 			id={lockerId}
 			disabled={disabled || reserved}
 			on:click={() => (selectedId = lockerId)}


### PR DESCRIPTION
- `LockerList` 의 x-axis 에 margin 을 고르게 분배하고, `LockerItem` 사이의 공간은 `gap-4` 로 처리(#273)